### PR TITLE
Improve testability, add .NET 6 target framework, and update NuGet packages

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
   <PropertyGroup>
     <Product>CustomerLoans - Konzole 2.0</Product>
-    <Version>1.0.4</Version>
+    <Version>2.0.0-beta.1</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/Huobi.Client.Websocket/Authentication/HuobiAuthenticationRequestFactory.cs
+++ b/src/Huobi.Client.Websocket/Authentication/HuobiAuthenticationRequestFactory.cs
@@ -3,41 +3,40 @@ using Huobi.Client.Websocket.Config;
 using Huobi.Client.Websocket.Messages.Account;
 using Huobi.Client.Websocket.Utils;
 
-namespace Huobi.Client.Websocket.Authentication
+namespace Huobi.Client.Websocket.Authentication;
+
+public class HuobiAuthenticationRequestFactory : IHuobiAuthenticationRequestFactory
 {
-    public class HuobiAuthenticationRequestFactory : IHuobiAuthenticationRequestFactory
+    private readonly IHuobiDateTimeProvider _dateTimeProvider;
+    private readonly IHuobiSignature _signature;
+
+    public HuobiAuthenticationRequestFactory(
+        IHuobiDateTimeProvider dateTimeProvider,
+        IHuobiSignature signature)
     {
-        private readonly IHuobiDateTimeProvider _dateTimeProvider;
-        private readonly IHuobiSignature _signature;
+        _dateTimeProvider = dateTimeProvider;
+        _signature = signature;
+    }
 
-        public HuobiAuthenticationRequestFactory(
-            IHuobiDateTimeProvider dateTimeProvider,
-            IHuobiSignature signature)
-        {
-            _dateTimeProvider = dateTimeProvider;
-            _signature = signature;
-        }
-
-        public AuthenticationRequest CreateRequest(HuobiAccountWebsocketClientConfig config)
-        {
-            Validations.ValidateInput(config.Url, nameof(config.Url));
-            Validations.ValidateInput(config.AccessKey, nameof(config.AccessKey));
-            Validations.ValidateInput(config.SecretKey, nameof(config.SecretKey));
+    public AuthenticationRequest CreateRequest(HuobiAccountWebsocketClientConfig config)
+    {
+        Validations.ValidateInput(config.Url, nameof(config.Url));
+        Validations.ValidateInput(config.AccessKey, nameof(config.AccessKey));
+        Validations.ValidateInput(config.SecretKey, nameof(config.SecretKey));
             
-            var uri = new Uri(config.Url!);
-            return CreateRequest(uri, config.AccessKey!, config.SecretKey!);
-        }
+        var uri = new Uri(config.Url!);
+        return CreateRequest(uri, config.AccessKey!, config.SecretKey!);
+    }
 
-        public AuthenticationRequest CreateRequest(Uri uri, string accessKey, string secretKey)
-        {
-            var now = _dateTimeProvider.UtcNow;
-            var signature = _signature.Create(
-                accessKey,
-                secretKey,
-                uri.Host,
-                uri.LocalPath,
-                now);
-            return new AuthenticationRequest(accessKey, signature, now);
-        }
+    public AuthenticationRequest CreateRequest(Uri uri, string accessKey, string secretKey)
+    {
+        var now = _dateTimeProvider.UtcNow;
+        var signature = _signature.Create(
+            accessKey,
+            secretKey,
+            uri.Host,
+            uri.LocalPath,
+            now);
+        return new AuthenticationRequest(accessKey, signature, now);
     }
 }

--- a/src/Huobi.Client.Websocket/Authentication/HuobiSignature.cs
+++ b/src/Huobi.Client.Websocket/Authentication/HuobiSignature.cs
@@ -5,62 +5,61 @@ using System.Text;
 using Huobi.Client.Websocket.Utils;
 using Microsoft.AspNetCore.Http;
 
-namespace Huobi.Client.Websocket.Authentication
+namespace Huobi.Client.Websocket.Authentication;
+
+public class HuobiSignature : IHuobiSignature
 {
-    public class HuobiSignature : IHuobiSignature
+    private const string METHOD = "GET";
+    private const string NEW_LINE_CHAR = "\n";
+    private const string ACCESS_KEY_NAME = "accessKey";
+    private const string TIMESTAMP_NAME = "timestamp";
+
+    private const string SIGNATURE_METHOD_NAME = "signatureMethod";
+    internal const string SIGNATURE_METHOD_VALUE = "HmacSHA256";
+
+    private const string SIGNATURE_VERSION_NAME = "signatureVersion";
+    internal const string SIGNATURE_VERSION_VERSION = "2.1";
+
+    public string Create(string accessKey, string secretKey, string host, string uri, DateTimeOffset timestamp)
     {
-        private const string METHOD = "GET";
-        private const string NEW_LINE_CHAR = "\n";
-        private const string ACCESS_KEY_NAME = "accessKey";
-        private const string TIMESTAMP_NAME = "timestamp";
+        var secretKeyBytes = Encoding.UTF8.GetBytes(secretKey);
+        using var hmacSha256 = new HMACSHA256(secretKeyBytes);
 
-        private const string SIGNATURE_METHOD_NAME = "signatureMethod";
-        internal const string SIGNATURE_METHOD_VALUE = "HmacSHA256";
+        var requestString = CreateRequestString(accessKey, host, uri, timestamp);
+        var requestStringBytes = Encoding.UTF8.GetBytes(requestString);
+        var requestStringHash = hmacSha256.ComputeHash(requestStringBytes);
 
-        private const string SIGNATURE_VERSION_NAME = "signatureVersion";
-        internal const string SIGNATURE_VERSION_VERSION = "2.1";
+        var signature = Convert.ToBase64String(requestStringHash);
+        return signature;
+    }
 
-        public string Create(string accessKey, string secretKey, string host, string uri, DateTimeOffset timestamp)
+    private static string CreateRequestString(string accessKey, string host, string uri, DateTimeOffset timestamp)
+    {
+        var requestStringBuilder = new StringBuilder(METHOD);
+        requestStringBuilder.Append(NEW_LINE_CHAR);
+        requestStringBuilder.Append(host);
+        requestStringBuilder.Append(NEW_LINE_CHAR);
+        requestStringBuilder.Append(uri);
+        requestStringBuilder.Append(NEW_LINE_CHAR);
+
+        var urlParams = CreateQueryString(accessKey, timestamp);
+        requestStringBuilder.Append(urlParams);
+
+        var requestString = requestStringBuilder.ToString();
+        return requestString;
+    }
+
+    private static string CreateQueryString(string accessKey, DateTimeOffset timestamp)
+    {
+        var urlParamsDict = new Dictionary<string, string>
         {
-            var secretKeyBytes = Encoding.UTF8.GetBytes(secretKey);
-            using var hmacSha256 = new HMACSHA256(secretKeyBytes);
+            { ACCESS_KEY_NAME, accessKey },
+            { SIGNATURE_METHOD_NAME, SIGNATURE_METHOD_VALUE },
+            { SIGNATURE_VERSION_NAME, SIGNATURE_VERSION_VERSION },
+            { TIMESTAMP_NAME, timestamp.ToHuobiUtcString() }
+        };
 
-            var requestString = CreateRequestString(accessKey, host, uri, timestamp);
-            var requestStringBytes = Encoding.UTF8.GetBytes(requestString);
-            var requestStringHash = hmacSha256.ComputeHash(requestStringBytes);
-
-            var signature = Convert.ToBase64String(requestStringHash);
-            return signature;
-        }
-
-        private static string CreateRequestString(string accessKey, string host, string uri, DateTimeOffset timestamp)
-        {
-            var requestStringBuilder = new StringBuilder(METHOD);
-            requestStringBuilder.Append(NEW_LINE_CHAR);
-            requestStringBuilder.Append(host);
-            requestStringBuilder.Append(NEW_LINE_CHAR);
-            requestStringBuilder.Append(uri);
-            requestStringBuilder.Append(NEW_LINE_CHAR);
-
-            var urlParams = CreateQueryString(accessKey, timestamp);
-            requestStringBuilder.Append(urlParams);
-
-            var requestString = requestStringBuilder.ToString();
-            return requestString;
-        }
-
-        private static string CreateQueryString(string accessKey, DateTimeOffset timestamp)
-        {
-            var urlParamsDict = new Dictionary<string, string>
-            {
-                { ACCESS_KEY_NAME, accessKey },
-                { SIGNATURE_METHOD_NAME, SIGNATURE_METHOD_VALUE },
-                { SIGNATURE_VERSION_NAME, SIGNATURE_VERSION_VERSION },
-                { TIMESTAMP_NAME, timestamp.ToHuobiUtcString() }
-            };
-
-            var urlParams = QueryString.Create(urlParamsDict);
-            return urlParams.Value.Substring(1); // removes initial question mark
-        }
+        var urlParams = QueryString.Create(urlParamsDict);
+        return urlParams.Value.Substring(1); // removes initial question mark
     }
 }

--- a/src/Huobi.Client.Websocket/Authentication/IHuobiAuthenticationRequestFactory.cs
+++ b/src/Huobi.Client.Websocket/Authentication/IHuobiAuthenticationRequestFactory.cs
@@ -2,11 +2,10 @@
 using Huobi.Client.Websocket.Config;
 using Huobi.Client.Websocket.Messages.Account;
 
-namespace Huobi.Client.Websocket.Authentication
+namespace Huobi.Client.Websocket.Authentication;
+
+public interface IHuobiAuthenticationRequestFactory
 {
-    public interface IHuobiAuthenticationRequestFactory
-    {
-        AuthenticationRequest CreateRequest(HuobiAccountWebsocketClientConfig config);
-        AuthenticationRequest CreateRequest(Uri uri, string accessKey, string secretKey);
-    }
+    AuthenticationRequest CreateRequest(HuobiAccountWebsocketClientConfig config);
+    AuthenticationRequest CreateRequest(Uri uri, string accessKey, string secretKey);
 }

--- a/src/Huobi.Client.Websocket/Authentication/IHuobiSignature.cs
+++ b/src/Huobi.Client.Websocket/Authentication/IHuobiSignature.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Authentication
+namespace Huobi.Client.Websocket.Authentication;
+
+public interface IHuobiSignature
 {
-    public interface IHuobiSignature
-    {
-        string Create(string accessKey, string secretKey, string host, string uri, DateTimeOffset timestamp);
-    }
+    string Create(string accessKey, string secretKey, string host, string uri, DateTimeOffset timestamp);
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiAccountWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiAccountWebsocketClient.cs
@@ -11,132 +11,131 @@ using Huobi.Client.Websocket.Serializer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccountClientStreams>, IHuobiAccountWebsocketClient
 {
-    public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccountClientStreams>, IHuobiAccountWebsocketClient
+    private readonly IOptions<HuobiAccountWebsocketClientConfig> _config;
+    private readonly IHuobiAuthenticationRequestFactory _authenticationRequestFactory;
+
+    public HuobiAccountWebsocketClient(
+        IOptions<HuobiAccountWebsocketClientConfig> config,
+        IHuobiAccountWebsocketCommunicator communicator,
+        IHuobiSerializer serializer,
+        IHuobiAuthenticationRequestFactory authenticationRequestFactory,
+        ILogger<HuobiAccountWebsocketClient> logger)
+        : base(communicator, serializer, logger)
     {
-        private readonly IOptions<HuobiAccountWebsocketClientConfig> _config;
-        private readonly IHuobiAuthenticationRequestFactory _authenticationRequestFactory;
+        _config = config;
+        _authenticationRequestFactory = authenticationRequestFactory;
+    }
 
-        public HuobiAccountWebsocketClient(
-            IOptions<HuobiAccountWebsocketClientConfig> config,
-            IHuobiAccountWebsocketCommunicator communicator,
-            IHuobiSerializer serializer,
-            IHuobiAuthenticationRequestFactory authenticationRequestFactory,
-            ILogger<HuobiAccountWebsocketClient> logger)
-            : base(communicator, serializer, logger)
+    public override async Task Start()
+    {
+        await base.Start();
+        Authenticate();
+    }
+
+    public void Send(AccountRequestBase request)
+    {
+        var serialized = Serializer.Serialize(request);
+        Send(serialized);
+    }
+
+    protected override bool TryHandleMessage(string message)
+    {
+        return TryHandleTradeDetailsMessages(message)
+               || TryHandleOrderUpdateMessages(message)
+               || TryHandleAccountUpdateMessages(message)
+               || TryHandleSubscribeResponses(message)
+               || TryHandleAuthenticationResponses(message);
+    }
+
+    private void Authenticate()
+    {
+        var request = _authenticationRequestFactory.CreateRequest(_config.Value);
+        Send(request);
+    }
+
+    private bool TryHandleTradeDetailsMessages(string message)
+    {
+        if (TradeDetailsMessage.TryParse(Serializer, message, out var tradeDetailsMessage))
         {
-            _config = config;
-            _authenticationRequestFactory = authenticationRequestFactory;
+            Streams.TradeDetailsMessageSubject.OnNext(tradeDetailsMessage);
+            return true;
         }
 
-        public override async Task Start()
-        {
-            await base.Start();
-            Authenticate();
-        }
+        return false;
+    }
 
-        public void Send(AccountRequestBase request)
-        {
-            var serialized = Serializer.Serialize(request);
-            Send(serialized);
-        }
-
-        protected override bool TryHandleMessage(string message)
-        {
-            return TryHandleTradeDetailsMessages(message)
-                || TryHandleOrderUpdateMessages(message)
-                || TryHandleAccountUpdateMessages(message)
-                || TryHandleSubscribeResponses(message)
-                || TryHandleAuthenticationResponses(message);
-        }
-
-        private void Authenticate()
-        {
-            var request = _authenticationRequestFactory.CreateRequest(_config.Value);
-            Send(request);
-        }
-
-        private bool TryHandleTradeDetailsMessages(string message)
-        {
-            if (TradeDetailsMessage.TryParse(Serializer, message, out var tradeDetailsMessage))
-            {
-                Streams.TradeDetailsMessageSubject.OnNext(tradeDetailsMessage);
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TryHandleOrderUpdateMessages(string message)
-        {
-            if (ConditionalOrderTriggerFailureMessage.TryParse(
+    private bool TryHandleOrderUpdateMessages(string message)
+    {
+        if (ConditionalOrderTriggerFailureMessage.TryParse(
                 Serializer,
                 message,
                 out var conditionalOrderTriggerFailureMessage))
-            {
-                Streams.ConditionalOrderTriggerFailureMessageSubject.OnNext(conditionalOrderTriggerFailureMessage);
-                return true;
-            }
-
-            if (ConditionalOrderCanceledMessage.TryParse(Serializer, message, out var conditionalOrderCanceledMessage))
-            {
-                Streams.ConditionalOrderCanceledMessageSubject.OnNext(conditionalOrderCanceledMessage);
-                return true;
-            }
-
-            if (OrderSubmittedMessage.TryParse(Serializer, message, out var conditionalSubmittedMessage))
-            {
-                Streams.OrderSubmittedMessageSubject.OnNext(conditionalSubmittedMessage);
-                return true;
-            }
-
-            if (OrderTradedMessage.TryParse(Serializer, message, out var orderTradedMessage))
-            {
-                Streams.OrderTradedMessageSubject.OnNext(orderTradedMessage);
-                return true;
-            }
-
-            if (OrderCanceledMessage.TryParse(Serializer, message, out var orderCanceledMessage))
-            {
-                Streams.OrderCanceledMessageSubject.OnNext(orderCanceledMessage);
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TryHandleAccountUpdateMessages(string message)
         {
-            if (AccountUpdateMessage.TryParse(Serializer, message, out var accountUpdateMessage))
-            {
-                Streams.AccountUpdateMessageSubject.OnNext(accountUpdateMessage);
-                return true;
-            }
-
-            return false;
+            Streams.ConditionalOrderTriggerFailureMessageSubject.OnNext(conditionalOrderTriggerFailureMessage);
+            return true;
         }
 
-        private bool TryHandleSubscribeResponses(string message)
+        if (ConditionalOrderCanceledMessage.TryParse(Serializer, message, out var conditionalOrderCanceledMessage))
         {
-            if (AccountSubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
-            {
-                Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
-                return true;
-            }
-
-            return false;
+            Streams.ConditionalOrderCanceledMessageSubject.OnNext(conditionalOrderCanceledMessage);
+            return true;
         }
 
-        private bool TryHandleAuthenticationResponses(string message)
+        if (OrderSubmittedMessage.TryParse(Serializer, message, out var conditionalSubmittedMessage))
         {
-            if (AuthenticationResponse.TryParse(Serializer, message, out var authenticationResponse))
-            {
-                Streams.AuthenticationResponseSubject.OnNext(authenticationResponse);
-                return true;
-            }
-
-            return false;
+            Streams.OrderSubmittedMessageSubject.OnNext(conditionalSubmittedMessage);
+            return true;
         }
+
+        if (OrderTradedMessage.TryParse(Serializer, message, out var orderTradedMessage))
+        {
+            Streams.OrderTradedMessageSubject.OnNext(orderTradedMessage);
+            return true;
+        }
+
+        if (OrderCanceledMessage.TryParse(Serializer, message, out var orderCanceledMessage))
+        {
+            Streams.OrderCanceledMessageSubject.OnNext(orderCanceledMessage);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryHandleAccountUpdateMessages(string message)
+    {
+        if (AccountUpdateMessage.TryParse(Serializer, message, out var accountUpdateMessage))
+        {
+            Streams.AccountUpdateMessageSubject.OnNext(accountUpdateMessage);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryHandleSubscribeResponses(string message)
+    {
+        if (AccountSubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
+        {
+            Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryHandleAuthenticationResponses(string message)
+    {
+        if (AuthenticationResponse.TryParse(Serializer, message, out var authenticationResponse))
+        {
+            Streams.AuthenticationResponseSubject.OnNext(authenticationResponse);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiAccountWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiAccountWebsocketClient.cs
@@ -61,7 +61,7 @@ public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccount
     {
         if (TradeDetailsMessage.TryParse(Serializer, message, out var tradeDetailsMessage))
         {
-            Streams.TradeDetailsMessageSubject.OnNext(tradeDetailsMessage);
+            Streams.TradeDetailsMessageStream.OnNext(tradeDetailsMessage);
             return true;
         }
 
@@ -75,31 +75,31 @@ public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccount
                 message,
                 out var conditionalOrderTriggerFailureMessage))
         {
-            Streams.ConditionalOrderTriggerFailureMessageSubject.OnNext(conditionalOrderTriggerFailureMessage);
+            Streams.ConditionalOrderTriggerFailureMessageStream.OnNext(conditionalOrderTriggerFailureMessage);
             return true;
         }
 
         if (ConditionalOrderCanceledMessage.TryParse(Serializer, message, out var conditionalOrderCanceledMessage))
         {
-            Streams.ConditionalOrderCanceledMessageSubject.OnNext(conditionalOrderCanceledMessage);
+            Streams.ConditionalOrderCanceledMessageStream.OnNext(conditionalOrderCanceledMessage);
             return true;
         }
 
         if (OrderSubmittedMessage.TryParse(Serializer, message, out var conditionalSubmittedMessage))
         {
-            Streams.OrderSubmittedMessageSubject.OnNext(conditionalSubmittedMessage);
+            Streams.OrderSubmittedMessageStream.OnNext(conditionalSubmittedMessage);
             return true;
         }
 
         if (OrderTradedMessage.TryParse(Serializer, message, out var orderTradedMessage))
         {
-            Streams.OrderTradedMessageSubject.OnNext(orderTradedMessage);
+            Streams.OrderTradedMessageStream.OnNext(orderTradedMessage);
             return true;
         }
 
         if (OrderCanceledMessage.TryParse(Serializer, message, out var orderCanceledMessage))
         {
-            Streams.OrderCanceledMessageSubject.OnNext(orderCanceledMessage);
+            Streams.OrderCanceledMessageStream.OnNext(orderCanceledMessage);
             return true;
         }
 
@@ -110,7 +110,7 @@ public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccount
     {
         if (AccountUpdateMessage.TryParse(Serializer, message, out var accountUpdateMessage))
         {
-            Streams.AccountUpdateMessageSubject.OnNext(accountUpdateMessage);
+            Streams.AccountUpdateMessageStream.OnNext(accountUpdateMessage);
             return true;
         }
 
@@ -121,7 +121,7 @@ public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccount
     {
         if (AccountSubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
         {
-            Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
+            Streams.SubscribeResponseStream.OnNext(subscribeResponse);
             return true;
         }
 
@@ -132,7 +132,7 @@ public class HuobiAccountWebsocketClient : HuobiWebsocketClientBase<HuobiAccount
     {
         if (AuthenticationResponse.TryParse(Serializer, message, out var authenticationResponse))
         {
-            Streams.AuthenticationResponseSubject.OnNext(authenticationResponse);
+            Streams.AuthenticationResponseStream.OnNext(authenticationResponse);
             return true;
         }
 

--- a/src/Huobi.Client.Websocket/Clients/HuobiGenericWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiGenericWebsocketClient.cs
@@ -3,28 +3,27 @@ using Huobi.Client.Websocket.Communicator;
 using Huobi.Client.Websocket.Serializer;
 using Microsoft.Extensions.Logging;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public class HuobiGenericWebsocketClient : HuobiWebsocketClientBase<HuobiGenericClientStreams>, IHuobiGenericWebsocketClient
 {
-    public class HuobiGenericWebsocketClient : HuobiWebsocketClientBase<HuobiGenericClientStreams>, IHuobiGenericWebsocketClient
+    public HuobiGenericWebsocketClient(
+        IHuobiGenericWebsocketCommunicator communicator,
+        IHuobiSerializer serializer,
+        ILogger<HuobiGenericWebsocketClient> logger)
+        : base(communicator, serializer, logger)
     {
-        public HuobiGenericWebsocketClient(
-            IHuobiGenericWebsocketCommunicator communicator,
-            IHuobiSerializer serializer,
-            ILogger<HuobiGenericWebsocketClient> logger)
-            : base(communicator, serializer, logger)
-        {
-        }
+    }
 
-        public void Send(object request)
-        {
-            var serialized = Serializer.Serialize(request);
-            base.Send(serialized);
-        }
+    public void Send(object request)
+    {
+        var serialized = Serializer.Serialize(request);
+        base.Send(serialized);
+    }
 
-        protected override bool TryHandleMessage(string message)
-        {
-            Streams.ResponseMessageSubject.OnNext(message);
-            return true;
-        }
+    protected override bool TryHandleMessage(string message)
+    {
+        Streams.ResponseMessageSubject.OnNext(message);
+        return true;
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiGenericWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiGenericWebsocketClient.cs
@@ -23,7 +23,7 @@ public class HuobiGenericWebsocketClient : HuobiWebsocketClientBase<HuobiGeneric
 
     protected override bool TryHandleMessage(string message)
     {
-        Streams.ResponseMessageSubject.OnNext(message);
+        Streams.ResponseMessageStream.OnNext(message);
         return true;
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiMarketByPriceWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiMarketByPriceWebsocketClient.cs
@@ -5,69 +5,68 @@ using Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
 using Huobi.Client.Websocket.Serializer;
 using Microsoft.Extensions.Logging;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public class HuobiMarketByPriceWebsocketClient : HuobiWebsocketClientBase<HuobiMarketByPriceClientStreams>,
+    IHuobiMarketByPriceWebsocketClient
 {
-    public class HuobiMarketByPriceWebsocketClient : HuobiWebsocketClientBase<HuobiMarketByPriceClientStreams>,
-        IHuobiMarketByPriceWebsocketClient
+    public HuobiMarketByPriceWebsocketClient(
+        IHuobiMarketByPriceWebsocketCommunicator communicator,
+        IHuobiSerializer serializer,
+        ILogger<HuobiMarketByPriceWebsocketClient> logger)
+        : base(communicator, serializer, logger)
     {
-        public HuobiMarketByPriceWebsocketClient(
-            IHuobiMarketByPriceWebsocketCommunicator communicator,
-            IHuobiSerializer serializer,
-            ILogger<HuobiMarketByPriceWebsocketClient> logger)
-            : base(communicator, serializer, logger)
+    }
+
+    public void Send(RequestBase request)
+    {
+        var serialized = Serializer.Serialize(request);
+        Send(serialized);
+    }
+
+    protected override bool TryHandleMessage(string message)
+    {
+        return TryHandlePullResponses(message)
+               || TryHandleUpdateMessages(message)
+               || TryHandleSubscribeResponses(message);
+    }
+
+    private bool TryHandlePullResponses(string message)
+    {
+        if (MarketByPricePullResponse.TryParse(Serializer, message, out var marketByPrice))
         {
+            Streams.MarketByPricePullSubject.OnNext(marketByPrice);
+            return true;
         }
 
-        public void Send(RequestBase request)
+        return false;
+    }
+
+    private bool TryHandleUpdateMessages(string message)
+    {
+        if (MarketByPriceUpdateMessage.TryParse(Serializer, message, out var marketByPrice))
         {
-            var serialized = Serializer.Serialize(request);
-            Send(serialized);
+            Streams.MarketByPriceUpdateSubject.OnNext(marketByPrice);
+            return true;
         }
 
-        protected override bool TryHandleMessage(string message)
+        return false;
+    }
+
+    private bool TryHandleSubscribeResponses(string message)
+    {
+        if (SubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
         {
-            return TryHandlePullResponses(message)
-                || TryHandleUpdateMessages(message)
-                || TryHandleSubscribeResponses(message);
+            Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
+            return true;
         }
 
-        private bool TryHandlePullResponses(string message)
+        if (UnsubscribeResponse.TryParse(Serializer, message, out var unsubscribeResponse))
         {
-            if (MarketByPricePullResponse.TryParse(Serializer, message, out var marketByPrice))
-            {
-                Streams.MarketByPricePullSubject.OnNext(marketByPrice);
-                return true;
-            }
-
-            return false;
+            Streams.UnsubscribeResponseSubject.OnNext(unsubscribeResponse);
+            return true;
         }
 
-        private bool TryHandleUpdateMessages(string message)
-        {
-            if (MarketByPriceUpdateMessage.TryParse(Serializer, message, out var marketByPrice))
-            {
-                Streams.MarketByPriceUpdateSubject.OnNext(marketByPrice);
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool TryHandleSubscribeResponses(string message)
-        {
-            if (SubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
-            {
-                Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
-                return true;
-            }
-
-            if (UnsubscribeResponse.TryParse(Serializer, message, out var unsubscribeResponse))
-            {
-                Streams.UnsubscribeResponseSubject.OnNext(unsubscribeResponse);
-                return true;
-            }
-
-            return false;
-        }
+        return false;
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiMarketByPriceWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiMarketByPriceWebsocketClient.cs
@@ -35,7 +35,7 @@ public class HuobiMarketByPriceWebsocketClient : HuobiWebsocketClientBase<HuobiM
     {
         if (MarketByPricePullResponse.TryParse(Serializer, message, out var marketByPrice))
         {
-            Streams.MarketByPricePullSubject.OnNext(marketByPrice);
+            Streams.MarketByPricePullStream.OnNext(marketByPrice);
             return true;
         }
 
@@ -46,7 +46,7 @@ public class HuobiMarketByPriceWebsocketClient : HuobiWebsocketClientBase<HuobiM
     {
         if (MarketByPriceUpdateMessage.TryParse(Serializer, message, out var marketByPrice))
         {
-            Streams.MarketByPriceUpdateSubject.OnNext(marketByPrice);
+            Streams.MarketByPriceUpdateStream.OnNext(marketByPrice);
             return true;
         }
 
@@ -57,13 +57,13 @@ public class HuobiMarketByPriceWebsocketClient : HuobiWebsocketClientBase<HuobiM
     {
         if (SubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
         {
-            Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
+            Streams.SubscribeResponseStream.OnNext(subscribeResponse);
             return true;
         }
 
         if (UnsubscribeResponse.TryParse(Serializer, message, out var unsubscribeResponse))
         {
-            Streams.UnsubscribeResponseSubject.OnNext(unsubscribeResponse);
+            Streams.UnsubscribeResponseStream.OnNext(unsubscribeResponse);
             return true;
         }
 

--- a/src/Huobi.Client.Websocket/Clients/HuobiMarketWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiMarketWebsocketClient.cs
@@ -10,116 +10,115 @@ using Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
 using Huobi.Client.Websocket.Serializer;
 using Microsoft.Extensions.Logging;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public class HuobiMarketWebsocketClient : HuobiWebsocketClientBase<HuobiMarketClientStreams>, IHuobiMarketWebsocketClient
 {
-    public class HuobiMarketWebsocketClient : HuobiWebsocketClientBase<HuobiMarketClientStreams>, IHuobiMarketWebsocketClient
+    public HuobiMarketWebsocketClient(
+        IHuobiMarketWebsocketCommunicator communicator,
+        IHuobiSerializer serializer,
+        ILogger<HuobiMarketWebsocketClient> logger)
+        : base(communicator, serializer, logger)
     {
-        public HuobiMarketWebsocketClient(
-            IHuobiMarketWebsocketCommunicator communicator,
-            IHuobiSerializer serializer,
-            ILogger<HuobiMarketWebsocketClient> logger)
-            : base(communicator, serializer, logger)
+    }
+
+    public void Send(RequestBase request)
+    {
+        var serialized = Serializer.Serialize(request);
+        Send(serialized);
+    }
+
+    protected override bool TryHandleMessage(string message)
+    {
+        return TryHandlePullResponses(message)
+               || TryHandleUpdateMessages(message)
+               || TryHandleSubscribeResponses(message);
+    }
+
+    private bool TryHandlePullResponses(string message)
+    {
+        if (MarketCandlestickPullResponse.TryParse(Serializer, message, out var marketCandlestick))
         {
+            Streams.CandlestickPullSubject.OnNext(marketCandlestick);
+            return true;
         }
 
-        public void Send(RequestBase request)
+        if (MarketDepthPullResponse.TryParse(Serializer, message, out var marketDepth))
         {
-            var serialized = Serializer.Serialize(request);
-            Send(serialized);
+            Streams.DepthPullSubject.OnNext(marketDepth);
+            return true;
         }
 
-        protected override bool TryHandleMessage(string message)
+        if (MarketTradeDetailPullResponse.TryParse(Serializer, message, out var marketTradeDetail))
         {
-            return TryHandlePullResponses(message)
-                || TryHandleUpdateMessages(message)
-                || TryHandleSubscribeResponses(message);
+            Streams.TradeDetailPullSubject.OnNext(marketTradeDetail);
+            return true;
         }
 
-        private bool TryHandlePullResponses(string message)
+        if (MarketDetailsPullResponse.TryParse(Serializer, message, out var marketDetails))
         {
-            if (MarketCandlestickPullResponse.TryParse(Serializer, message, out var marketCandlestick))
-            {
-                Streams.CandlestickPullSubject.OnNext(marketCandlestick);
-                return true;
-            }
-
-            if (MarketDepthPullResponse.TryParse(Serializer, message, out var marketDepth))
-            {
-                Streams.DepthPullSubject.OnNext(marketDepth);
-                return true;
-            }
-
-            if (MarketTradeDetailPullResponse.TryParse(Serializer, message, out var marketTradeDetail))
-            {
-                Streams.TradeDetailPullSubject.OnNext(marketTradeDetail);
-                return true;
-            }
-
-            if (MarketDetailsPullResponse.TryParse(Serializer, message, out var marketDetails))
-            {
-                Streams.MarketDetailsPullSubject.OnNext(marketDetails);
-                return true;
-            }
-
-            return false;
+            Streams.MarketDetailsPullSubject.OnNext(marketDetails);
+            return true;
         }
 
-        private bool TryHandleUpdateMessages(string message)
+        return false;
+    }
+
+    private bool TryHandleUpdateMessages(string message)
+    {
+        if (MarketCandlestickUpdateMessage.TryParse(Serializer, message, out var marketCandlestick))
         {
-            if (MarketCandlestickUpdateMessage.TryParse(Serializer, message, out var marketCandlestick))
-            {
-                Streams.CandlestickUpdateSubject.OnNext(marketCandlestick);
-                return true;
-            }
-
-            if (MarketDepthUpdateMessage.TryParse(Serializer, message, out var marketDepth))
-            {
-                Streams.DepthUpdateSubject.OnNext(marketDepth);
-                return true;
-            }
-
-            if (MarketByPriceRefreshUpdateMessage.TryParse(Serializer, message, out var marketByPriceRefresh))
-            {
-                Streams.MarketByPriceRefreshUpdateSubject.OnNext(marketByPriceRefresh);
-                return true;
-            }
-
-            if (MarketBestBidOfferUpdateMessage.TryParse(Serializer, message, out var marketBestBidOffer))
-            {
-                Streams.BestBidOfferUpdateSubject.OnNext(marketBestBidOffer);
-                return true;
-            }
-
-            if (MarketTradeDetailUpdateMessage.TryParse(Serializer, message, out var marketTradeDetail))
-            {
-                Streams.TradeDetailUpdateSubject.OnNext(marketTradeDetail);
-                return true;
-            }
-
-            if (MarketDetailsUpdateMessage.TryParse(Serializer, message, out var marketDetails))
-            {
-                Streams.MarketDetailsUpdateSubject.OnNext(marketDetails);
-                return true;
-            }
-
-            return false;
+            Streams.CandlestickUpdateSubject.OnNext(marketCandlestick);
+            return true;
         }
 
-        private bool TryHandleSubscribeResponses(string message)
+        if (MarketDepthUpdateMessage.TryParse(Serializer, message, out var marketDepth))
         {
-            if (SubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
-            {
-                Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
-                return true;
-            }
-
-            if (UnsubscribeResponse.TryParse(Serializer, message, out var unsubscribeResponse))
-            {
-                Streams.UnsubscribeResponseSubject.OnNext(unsubscribeResponse);
-                return true;
-            }
-
-            return false;
+            Streams.DepthUpdateSubject.OnNext(marketDepth);
+            return true;
         }
+
+        if (MarketByPriceRefreshUpdateMessage.TryParse(Serializer, message, out var marketByPriceRefresh))
+        {
+            Streams.MarketByPriceRefreshUpdateSubject.OnNext(marketByPriceRefresh);
+            return true;
+        }
+
+        if (MarketBestBidOfferUpdateMessage.TryParse(Serializer, message, out var marketBestBidOffer))
+        {
+            Streams.BestBidOfferUpdateSubject.OnNext(marketBestBidOffer);
+            return true;
+        }
+
+        if (MarketTradeDetailUpdateMessage.TryParse(Serializer, message, out var marketTradeDetail))
+        {
+            Streams.TradeDetailUpdateSubject.OnNext(marketTradeDetail);
+            return true;
+        }
+
+        if (MarketDetailsUpdateMessage.TryParse(Serializer, message, out var marketDetails))
+        {
+            Streams.MarketDetailsUpdateSubject.OnNext(marketDetails);
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryHandleSubscribeResponses(string message)
+    {
+        if (SubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
+        {
+            Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
+            return true;
+        }
+
+        if (UnsubscribeResponse.TryParse(Serializer, message, out var unsubscribeResponse))
+        {
+            Streams.UnsubscribeResponseSubject.OnNext(unsubscribeResponse);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiMarketWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiMarketWebsocketClient.cs
@@ -39,25 +39,25 @@ public class HuobiMarketWebsocketClient : HuobiWebsocketClientBase<HuobiMarketCl
     {
         if (MarketCandlestickPullResponse.TryParse(Serializer, message, out var marketCandlestick))
         {
-            Streams.CandlestickPullSubject.OnNext(marketCandlestick);
+            Streams.CandlestickPullStream.OnNext(marketCandlestick);
             return true;
         }
 
         if (MarketDepthPullResponse.TryParse(Serializer, message, out var marketDepth))
         {
-            Streams.DepthPullSubject.OnNext(marketDepth);
+            Streams.DepthPullStream.OnNext(marketDepth);
             return true;
         }
 
         if (MarketTradeDetailPullResponse.TryParse(Serializer, message, out var marketTradeDetail))
         {
-            Streams.TradeDetailPullSubject.OnNext(marketTradeDetail);
+            Streams.TradeDetailPullStream.OnNext(marketTradeDetail);
             return true;
         }
 
         if (MarketDetailsPullResponse.TryParse(Serializer, message, out var marketDetails))
         {
-            Streams.MarketDetailsPullSubject.OnNext(marketDetails);
+            Streams.MarketDetailsPullStream.OnNext(marketDetails);
             return true;
         }
 
@@ -68,37 +68,37 @@ public class HuobiMarketWebsocketClient : HuobiWebsocketClientBase<HuobiMarketCl
     {
         if (MarketCandlestickUpdateMessage.TryParse(Serializer, message, out var marketCandlestick))
         {
-            Streams.CandlestickUpdateSubject.OnNext(marketCandlestick);
+            Streams.CandlestickUpdateStream.OnNext(marketCandlestick);
             return true;
         }
 
         if (MarketDepthUpdateMessage.TryParse(Serializer, message, out var marketDepth))
         {
-            Streams.DepthUpdateSubject.OnNext(marketDepth);
+            Streams.DepthUpdateStream.OnNext(marketDepth);
             return true;
         }
 
         if (MarketByPriceRefreshUpdateMessage.TryParse(Serializer, message, out var marketByPriceRefresh))
         {
-            Streams.MarketByPriceRefreshUpdateSubject.OnNext(marketByPriceRefresh);
+            Streams.MarketByPriceRefreshUpdateStream.OnNext(marketByPriceRefresh);
             return true;
         }
 
         if (MarketBestBidOfferUpdateMessage.TryParse(Serializer, message, out var marketBestBidOffer))
         {
-            Streams.BestBidOfferUpdateSubject.OnNext(marketBestBidOffer);
+            Streams.BestBidOfferUpdateStream.OnNext(marketBestBidOffer);
             return true;
         }
 
         if (MarketTradeDetailUpdateMessage.TryParse(Serializer, message, out var marketTradeDetail))
         {
-            Streams.TradeDetailUpdateSubject.OnNext(marketTradeDetail);
+            Streams.TradeDetailUpdateStream.OnNext(marketTradeDetail);
             return true;
         }
 
         if (MarketDetailsUpdateMessage.TryParse(Serializer, message, out var marketDetails))
         {
-            Streams.MarketDetailsUpdateSubject.OnNext(marketDetails);
+            Streams.MarketDetailsUpdateStream.OnNext(marketDetails);
             return true;
         }
 
@@ -109,13 +109,13 @@ public class HuobiMarketWebsocketClient : HuobiWebsocketClientBase<HuobiMarketCl
     {
         if (SubscribeResponse.TryParse(Serializer, message, out var subscribeResponse))
         {
-            Streams.SubscribeResponseSubject.OnNext(subscribeResponse);
+            Streams.SubscribeResponseStream.OnNext(subscribeResponse);
             return true;
         }
 
         if (UnsubscribeResponse.TryParse(Serializer, message, out var unsubscribeResponse))
         {
-            Streams.UnsubscribeResponseSubject.OnNext(unsubscribeResponse);
+            Streams.UnsubscribeResponseStream.OnNext(unsubscribeResponse);
             return true;
         }
 

--- a/src/Huobi.Client.Websocket/Clients/HuobiWebsocketClientBase.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiWebsocketClientBase.cs
@@ -91,39 +91,39 @@ public abstract class HuobiWebsocketClientBase<TStreams> : IDisposable
 
             if (!processed)
             {
-                Streams.UnhandledMessageSubject.OnNext(message);
+                Streams.UnhandledMessageStream.OnNext(message);
                 _logger.LogError($"Unhandled message received: {message}");
             }
         }
         catch (Exception e)
         {
-            Streams.UnhandledMessageSubject.OnNext(message);
+            Streams.UnhandledMessageStream.OnNext(message);
             _logger.LogError(e, "Exception while processing of response message");
         }
     }
 
     private void HandleReconnectionInfoMessage(ReconnectionInfo info)
     {
-        Streams.ReconnectionInfoSubject.OnNext(info);
+        Streams.ReconnectionInfoStream.OnNext(info);
     }
 
     private void HandleDisconnectionInfoMessage(DisconnectionInfo info)
     {
-        Streams.DisconnectionInfoSubject.OnNext(info);
+        Streams.DisconnectionInfoStream.OnNext(info);
     }
 
     private bool TryHandleServerPingRequest(string message)
     {
         if (PingRequest.TryParse(Serializer, message, out var pingRequest))
         {
-            Streams.PingMessageSubject.OnNext(pingRequest);
+            Streams.PingMessageStream.OnNext(pingRequest);
             RespondWithPong(pingRequest);
             return true;
         }
 
         if (AccountPingRequest.TryParse(Serializer, message, out var pingAuthRequest))
         {
-            Streams.AccountPingMessageSubject.OnNext(pingAuthRequest);
+            Streams.AccountPingMessageStream.OnNext(pingAuthRequest);
             RespondWithPong(pingAuthRequest);
             return true;
         }
@@ -135,13 +135,13 @@ public abstract class HuobiWebsocketClientBase<TStreams> : IDisposable
     {
         if (ErrorMessage.TryParse(Serializer, message, out var errorMessage))
         {
-            Streams.ErrorMessageSubject.OnNext(errorMessage);
+            Streams.ErrorMessageStream.OnNext(errorMessage);
             return true;
         }
 
         if (AccountErrorMessage.TryParse(Serializer, message, out var authErrorMessage))
         {
-            Streams.AccountErrorMessageSubject.OnNext(authErrorMessage);
+            Streams.AccountErrorMessageStream.OnNext(authErrorMessage);
             return true;
         }
 

--- a/src/Huobi.Client.Websocket/Clients/HuobiWebsocketClientBase.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiWebsocketClientBase.cs
@@ -14,187 +14,186 @@ using Microsoft.Extensions.Logging;
 using Websocket.Client;
 using Websocket.Client.Models;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public abstract class HuobiWebsocketClientBase<TStreams> : IDisposable
+    where TStreams : HuobiClientStreamsBase, new()
 {
-    public abstract class HuobiWebsocketClientBase<TStreams> : IDisposable
-        where TStreams : HuobiClientStreamsBase, new()
+    private readonly ILogger<HuobiWebsocketClientBase<TStreams>> _logger;
+
+    private readonly IDisposable _messageReceivedSubscription;
+    private readonly IDisposable _reconnectionHappenedSubscription;
+    private readonly IDisposable _disconnectionHappenedSubscription;
+
+    protected HuobiWebsocketClientBase(
+        IHuobiGenericWebsocketCommunicator communicator,
+        IHuobiSerializer serializer,
+        ILogger<HuobiWebsocketClientBase<TStreams>> logger)
     {
-        private readonly ILogger<HuobiWebsocketClientBase<TStreams>> _logger;
+        Communicator = communicator;
+        Serializer = serializer;
+        _logger = logger;
 
-        private readonly IDisposable _messageReceivedSubscription;
-        private readonly IDisposable _reconnectionHappenedSubscription;
-        private readonly IDisposable _disconnectionHappenedSubscription;
+        _messageReceivedSubscription = Communicator.MessageReceived.Subscribe(HandleMessage);
+        _reconnectionHappenedSubscription = Communicator.ReconnectionHappened.Subscribe(HandleReconnectionInfoMessage);
+        _disconnectionHappenedSubscription = Communicator.DisconnectionHappened.Subscribe(HandleDisconnectionInfoMessage);
+    }
 
-        protected HuobiWebsocketClientBase(
-            IHuobiGenericWebsocketCommunicator communicator,
-            IHuobiSerializer serializer,
-            ILogger<HuobiWebsocketClientBase<TStreams>> logger)
+    protected IHuobiSerializer Serializer { get; }
+
+    public IHuobiGenericWebsocketCommunicator Communicator { get; }
+
+    [NotNull]
+    public TStreams Streams { get; } = new();
+
+    public void Dispose()
+    {
+        _messageReceivedSubscription.Dispose();
+        _reconnectionHappenedSubscription.Dispose();
+        _disconnectionHappenedSubscription.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public virtual Task Start()
+    {
+        return Communicator.Start();
+    }
+
+    public void Send(string request)
+    {
+        try
         {
-            Communicator = communicator;
-            Serializer = serializer;
-            _logger = logger;
-
-            _messageReceivedSubscription = Communicator.MessageReceived.Subscribe(HandleMessage);
-            _reconnectionHappenedSubscription = Communicator.ReconnectionHappened.Subscribe(HandleReconnectionInfoMessage);
-            _disconnectionHappenedSubscription = Communicator.DisconnectionHappened.Subscribe(HandleDisconnectionInfoMessage);
+            _logger.LogDebug($"Sending client request: {request}");
+            Communicator.Send(request);
         }
-
-        protected IHuobiSerializer Serializer { get; }
-
-        public IHuobiGenericWebsocketCommunicator Communicator { get; }
-
-        [NotNull]
-        public TStreams Streams { get; } = new();
-
-        public void Dispose()
+        catch (Exception ex)
         {
-            _messageReceivedSubscription.Dispose();
-            _reconnectionHappenedSubscription.Dispose();
-            _disconnectionHappenedSubscription.Dispose();
-            GC.SuppressFinalize(this);
+            _logger.LogError(ex, $"Exception while sending client request: '{request}'. Error: {ex.Message}");
+            throw;
         }
+    }
 
-        public virtual Task Start()
-        {
-            return Communicator.Start();
-        }
+    protected abstract bool TryHandleMessage(string message);
 
-        public void Send(string request)
+    private void HandleMessage(ResponseMessage responseMessage)
+    {
+        var message = ParseMessage(responseMessage);
+
+        try
         {
-            try
+            var processed = false;
+            if (message.StartsWith("{"))
             {
-                _logger.LogDebug($"Sending client request: {request}");
-                Communicator.Send(request);
+                processed = TryHandleServerPingRequest(message)
+                            || TryHandleMessage(message)
+                            || TryHandleErrorMessage(message);
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Exception while sending client request: '{request}'. Error: {ex.Message}");
-                throw;
-            }
-        }
 
-        protected abstract bool TryHandleMessage(string message);
-
-        private void HandleMessage(ResponseMessage responseMessage)
-        {
-            var message = ParseMessage(responseMessage);
-
-            try
-            {
-                var processed = false;
-                if (message.StartsWith("{"))
-                {
-                    processed = TryHandleServerPingRequest(message)
-                             || TryHandleMessage(message)
-                             || TryHandleErrorMessage(message);
-                }
-
-                if (!processed)
-                {
-                    Streams.UnhandledMessageSubject.OnNext(message);
-                    _logger.LogError($"Unhandled message received: {message}");
-                }
-            }
-            catch (Exception e)
+            if (!processed)
             {
                 Streams.UnhandledMessageSubject.OnNext(message);
-                _logger.LogError(e, "Exception while processing of response message");
+                _logger.LogError($"Unhandled message received: {message}");
             }
         }
-
-        private void HandleReconnectionInfoMessage(ReconnectionInfo info)
+        catch (Exception e)
         {
-            Streams.ReconnectionInfoSubject.OnNext(info);
+            Streams.UnhandledMessageSubject.OnNext(message);
+            _logger.LogError(e, "Exception while processing of response message");
+        }
+    }
+
+    private void HandleReconnectionInfoMessage(ReconnectionInfo info)
+    {
+        Streams.ReconnectionInfoSubject.OnNext(info);
+    }
+
+    private void HandleDisconnectionInfoMessage(DisconnectionInfo info)
+    {
+        Streams.DisconnectionInfoSubject.OnNext(info);
+    }
+
+    private bool TryHandleServerPingRequest(string message)
+    {
+        if (PingRequest.TryParse(Serializer, message, out var pingRequest))
+        {
+            Streams.PingMessageSubject.OnNext(pingRequest);
+            RespondWithPong(pingRequest);
+            return true;
         }
 
-        private void HandleDisconnectionInfoMessage(DisconnectionInfo info)
+        if (AccountPingRequest.TryParse(Serializer, message, out var pingAuthRequest))
         {
-            Streams.DisconnectionInfoSubject.OnNext(info);
+            Streams.AccountPingMessageSubject.OnNext(pingAuthRequest);
+            RespondWithPong(pingAuthRequest);
+            return true;
         }
 
-        private bool TryHandleServerPingRequest(string message)
+        return false;
+    }
+
+    private bool TryHandleErrorMessage(string message)
+    {
+        if (ErrorMessage.TryParse(Serializer, message, out var errorMessage))
         {
-            if (PingRequest.TryParse(Serializer, message, out var pingRequest))
+            Streams.ErrorMessageSubject.OnNext(errorMessage);
+            return true;
+        }
+
+        if (AccountErrorMessage.TryParse(Serializer, message, out var authErrorMessage))
+        {
+            Streams.AccountErrorMessageSubject.OnNext(authErrorMessage);
+            return true;
+        }
+
+        return false;
+    }
+
+    private void RespondWithPong(PingRequest pingRequest)
+    {
+        var clientResponse = new PongResponse(pingRequest.Value);
+        var serialized = Serializer.Serialize(clientResponse);
+        Send(serialized);
+    }
+
+    private void RespondWithPong(AccountPingRequest accountPingRequest)
+    {
+        if (accountPingRequest.Data is null)
+        {
+            return;
+        }
+
+        var clientResponse = new AccountPongResponse(accountPingRequest.Data.Timestamp);
+        var serialized = Serializer.Serialize(clientResponse);
+        Send(serialized);
+    }
+
+    private string ParseMessage(ResponseMessage message)
+    {
+        try
+        {
+            if (message.MessageType == WebSocketMessageType.Binary)
             {
-                Streams.PingMessageSubject.OnNext(pingRequest);
-                RespondWithPong(pingRequest);
-                return true;
+                return Decompress(message.Binary);
             }
 
-            if (AccountPingRequest.TryParse(Serializer, message, out var pingAuthRequest))
-            {
-                Streams.AccountPingMessageSubject.OnNext(pingAuthRequest);
-                RespondWithPong(pingAuthRequest);
-                return true;
-            }
-
-            return false;
+            return message.Text?.Trim() ?? string.Empty;
         }
-
-        private bool TryHandleErrorMessage(string message)
+        catch (Exception ex)
         {
-            if (ErrorMessage.TryParse(Serializer, message, out var errorMessage))
-            {
-                Streams.ErrorMessageSubject.OnNext(errorMessage);
-                return true;
-            }
-
-            if (AccountErrorMessage.TryParse(Serializer, message, out var authErrorMessage))
-            {
-                Streams.AccountErrorMessageSubject.OnNext(authErrorMessage);
-                return true;
-            }
-
-            return false;
+            _logger.LogError(ex, "Exception while parsing response message. Error: " + ex.Message);
+            return string.Empty;
         }
+    }
 
-        private void RespondWithPong(PingRequest pingRequest)
-        {
-            var clientResponse = new PongResponse(pingRequest.Value);
-            var serialized = Serializer.Serialize(clientResponse);
-            Send(serialized);
-        }
+    private static string Decompress(byte[] input)
+    {
+        using var inputStream = new MemoryStream(input);
+        using var gZipStream = new GZipStream(inputStream, CompressionMode.Decompress);
 
-        private void RespondWithPong(AccountPingRequest accountPingRequest)
-        {
-            if (accountPingRequest.Data is null)
-            {
-                return;
-            }
+        using var outputStream = new MemoryStream();
+        gZipStream.CopyTo(outputStream);
 
-            var clientResponse = new AccountPongResponse(accountPingRequest.Data.Timestamp);
-            var serialized = Serializer.Serialize(clientResponse);
-            Send(serialized);
-        }
-
-        private string ParseMessage(ResponseMessage message)
-        {
-            try
-            {
-                if (message.MessageType == WebSocketMessageType.Binary)
-                {
-                    return Decompress(message.Binary);
-                }
-
-                return message.Text?.Trim() ?? string.Empty;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Exception while parsing response message. Error: " + ex.Message);
-                return string.Empty;
-            }
-        }
-
-        private static string Decompress(byte[] input)
-        {
-            using var inputStream = new MemoryStream(input);
-            using var gZipStream = new GZipStream(inputStream, CompressionMode.Decompress);
-
-            using var outputStream = new MemoryStream();
-            gZipStream.CopyTo(outputStream);
-
-            var decompressed = Encoding.UTF8.GetString(outputStream.ToArray());
-            return decompressed;
-        }
+        var decompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+        return decompressed;
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/HuobiWebsocketClientsFactory.cs
+++ b/src/Huobi.Client.Websocket/Clients/HuobiWebsocketClientsFactory.cs
@@ -7,174 +7,173 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public static class HuobiWebsocketClientsFactory
 {
-    public static class HuobiWebsocketClientsFactory
+    public static IHuobiGenericWebsocketClient CreateGenericClient(
+        string url,
+        ILoggerFactory? loggerFactory = null)
     {
-        public static IHuobiGenericWebsocketClient CreateGenericClient(
-            string url,
-            ILoggerFactory? loggerFactory = null)
+        var config = new HuobiGenericWebsocketClientConfig
         {
-            var config = new HuobiGenericWebsocketClientConfig
+            Url = url
+        };
+
+        return CreateGenericClient(config, loggerFactory);
+    }
+
+    public static IHuobiGenericWebsocketClient CreateGenericClient(
+        HuobiGenericWebsocketClientConfig config,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var options = Options.Create(config);
+        var communicator = new HuobiGenericWebsocketCommunicator(options);
+        return CreateGenericClient(communicator, loggerFactory);
+    }
+
+    public static IHuobiGenericWebsocketClient CreateGenericClient(
+        IHuobiGenericWebsocketCommunicator communicator,
+        ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= NullLoggerFactory.Instance;
+
+        var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
+
+        return new HuobiGenericWebsocketClient(
+            communicator,
+            serializer,
+            loggerFactory.CreateLogger<HuobiGenericWebsocketClient>());
+    }
+
+    public static IHuobiMarketWebsocketClient CreateMarketClient(
+        string url,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var config = new HuobiMarketWebsocketClientConfig
+        {
+            Url = url
+        };
+
+        return CreateMarketClient(config, loggerFactory);
+    }
+
+    public static IHuobiMarketWebsocketClient CreateMarketClient(
+        HuobiMarketWebsocketClientConfig config,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var options = Options.Create(config);
+        var communicator = new HuobiMarketWebsocketCommunicator(options);
+        return CreateMarketClient(communicator, loggerFactory);
+    }
+
+    public static IHuobiMarketWebsocketClient CreateMarketClient(
+        IHuobiMarketWebsocketCommunicator communicator,
+        ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= NullLoggerFactory.Instance;
+
+        var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
+
+        return new HuobiMarketWebsocketClient(
+            communicator,
+            serializer,
+            loggerFactory.CreateLogger<HuobiMarketWebsocketClient>());
+    }
+
+    public static IHuobiMarketByPriceWebsocketClient CreateMarketByPriceClient(
+        string url,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var config = new HuobiMarketByPriceWebsocketClientConfig
+        {
+            Url = url
+        };
+
+        return CreateMarketByPriceClient(config, loggerFactory);
+    }
+
+    public static IHuobiMarketByPriceWebsocketClient CreateMarketByPriceClient(
+        HuobiMarketByPriceWebsocketClientConfig config,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var options = Options.Create(config);
+        var communicator = new HuobiMarketByPriceWebsocketCommunicator(options);
+        return CreateMarketByPriceClient(communicator, loggerFactory);
+    }
+
+    public static IHuobiMarketByPriceWebsocketClient CreateMarketByPriceClient(
+        IHuobiMarketByPriceWebsocketCommunicator communicator,
+        ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= NullLoggerFactory.Instance;
+
+        var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
+
+        return new HuobiMarketByPriceWebsocketClient(
+            communicator,
+            serializer,
+            loggerFactory.CreateLogger<HuobiMarketByPriceWebsocketClient>());
+    }
+
+    public static IHuobiAccountWebsocketClient CreateAccountClient(
+        string url,
+        string accessKey,
+        string secretKey,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var config = new HuobiAccountWebsocketClientConfig
+        {
+            Url = url,
+            AccessKey = accessKey,
+            SecretKey = secretKey
+        };
+
+        return CreateAccountClient(config, loggerFactory);
+    }
+
+    public static IHuobiAccountWebsocketClient CreateAccountClient(
+        HuobiAccountWebsocketClientConfig config,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var options = Options.Create(config);
+        var communicator = new HuobiAccountWebsocketCommunicator(options);
+        return CreateAccountClient(options, communicator, loggerFactory);
+    }
+
+    public static IHuobiAccountWebsocketClient CreateAccountClient(
+        IHuobiAccountWebsocketCommunicator communicator,
+        string accessKey,
+        string secretKey,
+        ILoggerFactory? loggerFactory = null)
+    {
+        var options = Options.Create(
+            new HuobiAccountWebsocketClientConfig
             {
-                Url = url
-            };
-
-            return CreateGenericClient(config, loggerFactory);
-        }
-
-        public static IHuobiGenericWebsocketClient CreateGenericClient(
-            HuobiGenericWebsocketClientConfig config,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var options = Options.Create(config);
-            var communicator = new HuobiGenericWebsocketCommunicator(options);
-            return CreateGenericClient(communicator, loggerFactory);
-        }
-
-        public static IHuobiGenericWebsocketClient CreateGenericClient(
-            IHuobiGenericWebsocketCommunicator communicator,
-            ILoggerFactory? loggerFactory = null)
-        {
-            loggerFactory ??= NullLoggerFactory.Instance;
-
-            var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
-
-            return new HuobiGenericWebsocketClient(
-                communicator,
-                serializer,
-                loggerFactory.CreateLogger<HuobiGenericWebsocketClient>());
-        }
-
-        public static IHuobiMarketWebsocketClient CreateMarketClient(
-            string url,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var config = new HuobiMarketWebsocketClientConfig
-            {
-                Url = url
-            };
-
-            return CreateMarketClient(config, loggerFactory);
-        }
-
-        public static IHuobiMarketWebsocketClient CreateMarketClient(
-            HuobiMarketWebsocketClientConfig config,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var options = Options.Create(config);
-            var communicator = new HuobiMarketWebsocketCommunicator(options);
-            return CreateMarketClient(communicator, loggerFactory);
-        }
-
-        public static IHuobiMarketWebsocketClient CreateMarketClient(
-            IHuobiMarketWebsocketCommunicator communicator,
-            ILoggerFactory? loggerFactory = null)
-        {
-            loggerFactory ??= NullLoggerFactory.Instance;
-
-            var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
-
-            return new HuobiMarketWebsocketClient(
-                communicator,
-                serializer,
-                loggerFactory.CreateLogger<HuobiMarketWebsocketClient>());
-        }
-
-        public static IHuobiMarketByPriceWebsocketClient CreateMarketByPriceClient(
-            string url,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var config = new HuobiMarketByPriceWebsocketClientConfig
-            {
-                Url = url
-            };
-
-            return CreateMarketByPriceClient(config, loggerFactory);
-        }
-
-        public static IHuobiMarketByPriceWebsocketClient CreateMarketByPriceClient(
-            HuobiMarketByPriceWebsocketClientConfig config,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var options = Options.Create(config);
-            var communicator = new HuobiMarketByPriceWebsocketCommunicator(options);
-            return CreateMarketByPriceClient(communicator, loggerFactory);
-        }
-
-        public static IHuobiMarketByPriceWebsocketClient CreateMarketByPriceClient(
-            IHuobiMarketByPriceWebsocketCommunicator communicator,
-            ILoggerFactory? loggerFactory = null)
-        {
-            loggerFactory ??= NullLoggerFactory.Instance;
-
-            var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
-
-            return new HuobiMarketByPriceWebsocketClient(
-                communicator,
-                serializer,
-                loggerFactory.CreateLogger<HuobiMarketByPriceWebsocketClient>());
-        }
-
-        public static IHuobiAccountWebsocketClient CreateAccountClient(
-            string url,
-            string accessKey,
-            string secretKey,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var config = new HuobiAccountWebsocketClientConfig
-            {
-                Url = url,
+                Url = communicator.Url.AbsoluteUri,
                 AccessKey = accessKey,
                 SecretKey = secretKey
-            };
+            });
+        return CreateAccountClient(options, communicator, loggerFactory);
+    }
 
-            return CreateAccountClient(config, loggerFactory);
-        }
+    private static IHuobiAccountWebsocketClient CreateAccountClient(
+        IOptions<HuobiAccountWebsocketClientConfig> config,
+        IHuobiAccountWebsocketCommunicator communicator,
+        ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= NullLoggerFactory.Instance;
 
-        public static IHuobiAccountWebsocketClient CreateAccountClient(
-            HuobiAccountWebsocketClientConfig config,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var options = Options.Create(config);
-            var communicator = new HuobiAccountWebsocketCommunicator(options);
-            return CreateAccountClient(options, communicator, loggerFactory);
-        }
+        var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
+        var dateTimeProvider = new HuobiDateTimeProvider();
+        var signature = new HuobiSignature();
+        var authenticationRequestFactory = new HuobiAuthenticationRequestFactory(dateTimeProvider, signature);
 
-        public static IHuobiAccountWebsocketClient CreateAccountClient(
-            IHuobiAccountWebsocketCommunicator communicator,
-            string accessKey,
-            string secretKey,
-            ILoggerFactory? loggerFactory = null)
-        {
-            var options = Options.Create(
-                new HuobiAccountWebsocketClientConfig
-                {
-                    Url = communicator.Url.AbsoluteUri,
-                    AccessKey = accessKey,
-                    SecretKey = secretKey
-                });
-            return CreateAccountClient(options, communicator, loggerFactory);
-        }
-
-        private static IHuobiAccountWebsocketClient CreateAccountClient(
-            IOptions<HuobiAccountWebsocketClientConfig> config,
-            IHuobiAccountWebsocketCommunicator communicator,
-            ILoggerFactory? loggerFactory = null)
-        {
-            loggerFactory ??= NullLoggerFactory.Instance;
-
-            var serializer = new HuobiSerializer(loggerFactory.CreateLogger<HuobiSerializer>());
-            var dateTimeProvider = new HuobiDateTimeProvider();
-            var signature = new HuobiSignature();
-            var authenticationRequestFactory = new HuobiAuthenticationRequestFactory(dateTimeProvider, signature);
-
-            return new HuobiAccountWebsocketClient(
-                config,
-                communicator,
-                serializer,
-                authenticationRequestFactory,
-                loggerFactory.CreateLogger<HuobiAccountWebsocketClient>());
-        }
+        return new HuobiAccountWebsocketClient(
+            config,
+            communicator,
+            serializer,
+            authenticationRequestFactory,
+            loggerFactory.CreateLogger<HuobiAccountWebsocketClient>());
     }
 }

--- a/src/Huobi.Client.Websocket/Clients/IHuobiAccountWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/IHuobiAccountWebsocketClient.cs
@@ -1,9 +1,8 @@
 ﻿using Huobi.Client.Websocket.Clients.Streams;
 using Huobi.Client.Websocket.Messages.Account;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public interface IHuobiAccountWebsocketClient : IHuobiWebsocketClient<HuobiAccountClientStreams, AccountRequestBase>
 {
-    public interface IHuobiAccountWebsocketClient : IHuobiWebsocketClient<HuobiAccountClientStreams, AccountRequestBase>
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Clients/IHuobiGenericWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/IHuobiGenericWebsocketClient.cs
@@ -1,8 +1,7 @@
 ﻿using Huobi.Client.Websocket.Clients.Streams;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public interface IHuobiGenericWebsocketClient : IHuobiWebsocketClient<HuobiGenericClientStreams, object>
 {
-    public interface IHuobiGenericWebsocketClient : IHuobiWebsocketClient<HuobiGenericClientStreams, object>
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Clients/IHuobiMarketByPriceWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/IHuobiMarketByPriceWebsocketClient.cs
@@ -1,9 +1,8 @@
 ﻿using Huobi.Client.Websocket.Clients.Streams;
 using Huobi.Client.Websocket.Messages.MarketData;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public interface IHuobiMarketByPriceWebsocketClient : IHuobiWebsocketClient<HuobiMarketByPriceClientStreams, RequestBase>
 {
-    public interface IHuobiMarketByPriceWebsocketClient : IHuobiWebsocketClient<HuobiMarketByPriceClientStreams, RequestBase>
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Clients/IHuobiMarketWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/IHuobiMarketWebsocketClient.cs
@@ -1,9 +1,8 @@
 ﻿using Huobi.Client.Websocket.Clients.Streams;
 using Huobi.Client.Websocket.Messages.MarketData;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public interface IHuobiMarketWebsocketClient : IHuobiWebsocketClient<HuobiMarketClientStreams, RequestBase>
 {
-    public interface IHuobiMarketWebsocketClient : IHuobiWebsocketClient<HuobiMarketClientStreams, RequestBase>
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Clients/IHuobiWebsocketClient.cs
+++ b/src/Huobi.Client.Websocket/Clients/IHuobiWebsocketClient.cs
@@ -2,14 +2,13 @@
 using System.Threading.Tasks;
 using Huobi.Client.Websocket.Communicator;
 
-namespace Huobi.Client.Websocket.Clients
+namespace Huobi.Client.Websocket.Clients;
+
+public interface IHuobiWebsocketClient<out TStreams, in TRequest> : IDisposable
 {
-    public interface IHuobiWebsocketClient<out TStreams, in TRequest> : IDisposable
-    {
-        IHuobiGenericWebsocketCommunicator Communicator { get; }
-        TStreams Streams { get; }
-        Task Start();
-        void Send(TRequest request);
-        void Send(string request);
-    }
+    IHuobiGenericWebsocketCommunicator Communicator { get; }
+    TStreams Streams { get; }
+    Task Start();
+    void Send(TRequest request);
+    void Send(string request);
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiAccountClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiAccountClientStreams.cs
@@ -6,34 +6,33 @@ using Huobi.Client.Websocket.Messages.Account.AccountUpdates;
 using Huobi.Client.Websocket.Messages.Account.OrderUpdates;
 using Huobi.Client.Websocket.Messages.Account.TradeDetails;
 
-namespace Huobi.Client.Websocket.Clients.Streams
+namespace Huobi.Client.Websocket.Clients.Streams;
+
+public class HuobiAccountClientStreams : HuobiClientStreamsBase
 {
-    public class HuobiAccountClientStreams : HuobiClientStreamsBase
-    {
-        internal readonly Subject<AuthenticationResponse> AuthenticationResponseSubject = new();
-        internal readonly Subject<AccountSubscribeResponse> SubscribeResponseSubject = new();
+    internal readonly Subject<AuthenticationResponse> AuthenticationResponseSubject = new();
+    internal readonly Subject<AccountSubscribeResponse> SubscribeResponseSubject = new();
 
-        internal readonly Subject<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageSubject = new();
-        internal readonly Subject<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageSubject = new();
-        internal readonly Subject<OrderSubmittedMessage> OrderSubmittedMessageSubject = new();
-        internal readonly Subject<OrderTradedMessage> OrderTradedMessageSubject = new();
-        internal readonly Subject<OrderCanceledMessage> OrderCanceledMessageSubject = new();
+    internal readonly Subject<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageSubject = new();
+    internal readonly Subject<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageSubject = new();
+    internal readonly Subject<OrderSubmittedMessage> OrderSubmittedMessageSubject = new();
+    internal readonly Subject<OrderTradedMessage> OrderTradedMessageSubject = new();
+    internal readonly Subject<OrderCanceledMessage> OrderCanceledMessageSubject = new();
         
-        internal readonly Subject<TradeDetailsMessage> TradeDetailsMessageSubject = new();
+    internal readonly Subject<TradeDetailsMessage> TradeDetailsMessageSubject = new();
         
-        internal readonly Subject<AccountUpdateMessage> AccountUpdateMessageSubject = new();
+    internal readonly Subject<AccountUpdateMessage> AccountUpdateMessageSubject = new();
 
-        public IObservable<AuthenticationResponse> AuthenticationResponseStream => AuthenticationResponseSubject.AsObservable();
-        public IObservable<AccountSubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
+    public IObservable<AuthenticationResponse> AuthenticationResponseStream => AuthenticationResponseSubject.AsObservable();
+    public IObservable<AccountSubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
         
-        public IObservable<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageStream => ConditionalOrderTriggerFailureMessageSubject.AsObservable();
-        public IObservable<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageStream => ConditionalOrderCanceledMessageSubject.AsObservable();
-        public IObservable<OrderSubmittedMessage> OrderSubmittedMessageStream => OrderSubmittedMessageSubject.AsObservable();
-        public IObservable<OrderTradedMessage> OrderTradedMessageStream => OrderTradedMessageSubject.AsObservable();
-        public IObservable<OrderCanceledMessage> OrderCanceledMessageStream => OrderCanceledMessageSubject.AsObservable();
+    public IObservable<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageStream => ConditionalOrderTriggerFailureMessageSubject.AsObservable();
+    public IObservable<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageStream => ConditionalOrderCanceledMessageSubject.AsObservable();
+    public IObservable<OrderSubmittedMessage> OrderSubmittedMessageStream => OrderSubmittedMessageSubject.AsObservable();
+    public IObservable<OrderTradedMessage> OrderTradedMessageStream => OrderTradedMessageSubject.AsObservable();
+    public IObservable<OrderCanceledMessage> OrderCanceledMessageStream => OrderCanceledMessageSubject.AsObservable();
 
-        public IObservable<TradeDetailsMessage> TradeDetailsMessageStream => TradeDetailsMessageSubject.AsObservable();
+    public IObservable<TradeDetailsMessage> TradeDetailsMessageStream => TradeDetailsMessageSubject.AsObservable();
 
-        public IObservable<AccountUpdateMessage> AccountUpdateMessageStream => AccountUpdateMessageSubject.AsObservable();
-    }
+    public IObservable<AccountUpdateMessage> AccountUpdateMessageStream => AccountUpdateMessageSubject.AsObservable();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiAccountClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiAccountClientStreams.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+﻿using System.Reactive.Subjects;
 using Huobi.Client.Websocket.Messages.Account;
 using Huobi.Client.Websocket.Messages.Account.AccountUpdates;
 using Huobi.Client.Websocket.Messages.Account.OrderUpdates;
@@ -10,29 +8,16 @@ namespace Huobi.Client.Websocket.Clients.Streams;
 
 public class HuobiAccountClientStreams : HuobiClientStreamsBase
 {
-    internal readonly Subject<AuthenticationResponse> AuthenticationResponseSubject = new();
-    internal readonly Subject<AccountSubscribeResponse> SubscribeResponseSubject = new();
-
-    internal readonly Subject<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageSubject = new();
-    internal readonly Subject<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageSubject = new();
-    internal readonly Subject<OrderSubmittedMessage> OrderSubmittedMessageSubject = new();
-    internal readonly Subject<OrderTradedMessage> OrderTradedMessageSubject = new();
-    internal readonly Subject<OrderCanceledMessage> OrderCanceledMessageSubject = new();
+    public readonly Subject<AuthenticationResponse> AuthenticationResponseStream = new();
+    public readonly Subject<AccountSubscribeResponse> SubscribeResponseStream = new();
         
-    internal readonly Subject<TradeDetailsMessage> TradeDetailsMessageSubject = new();
-        
-    internal readonly Subject<AccountUpdateMessage> AccountUpdateMessageSubject = new();
+    public readonly Subject<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageStream = new();
+    public readonly Subject<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageStream = new();
+    public readonly Subject<OrderSubmittedMessage> OrderSubmittedMessageStream = new();
+    public readonly Subject<OrderTradedMessage> OrderTradedMessageStream = new();
+    public readonly Subject<OrderCanceledMessage> OrderCanceledMessageStream = new();
 
-    public IObservable<AuthenticationResponse> AuthenticationResponseStream => AuthenticationResponseSubject.AsObservable();
-    public IObservable<AccountSubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
-        
-    public IObservable<ConditionalOrderTriggerFailureMessage> ConditionalOrderTriggerFailureMessageStream => ConditionalOrderTriggerFailureMessageSubject.AsObservable();
-    public IObservable<ConditionalOrderCanceledMessage> ConditionalOrderCanceledMessageStream => ConditionalOrderCanceledMessageSubject.AsObservable();
-    public IObservable<OrderSubmittedMessage> OrderSubmittedMessageStream => OrderSubmittedMessageSubject.AsObservable();
-    public IObservable<OrderTradedMessage> OrderTradedMessageStream => OrderTradedMessageSubject.AsObservable();
-    public IObservable<OrderCanceledMessage> OrderCanceledMessageStream => OrderCanceledMessageSubject.AsObservable();
+    public readonly Subject<TradeDetailsMessage> TradeDetailsMessageStream = new();
 
-    public IObservable<TradeDetailsMessage> TradeDetailsMessageStream => TradeDetailsMessageSubject.AsObservable();
-
-    public IObservable<AccountUpdateMessage> AccountUpdateMessageStream => AccountUpdateMessageSubject.AsObservable();
+    public readonly Subject<AccountUpdateMessage> AccountUpdateMessageStream = new();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiClientStreamsBase.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiClientStreamsBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+﻿using System.Reactive.Subjects;
 using Huobi.Client.Websocket.Messages.Account;
 using Huobi.Client.Websocket.Messages.MarketData;
 using Websocket.Client;
@@ -10,19 +8,11 @@ namespace Huobi.Client.Websocket.Clients.Streams;
 
 public class HuobiClientStreamsBase
 {
-    internal readonly Subject<ReconnectionInfo> ReconnectionInfoSubject = new();
-    internal readonly Subject<DisconnectionInfo> DisconnectionInfoSubject = new();
-    internal readonly Subject<string> UnhandledMessageSubject = new();
-    internal readonly Subject<ErrorMessage> ErrorMessageSubject = new();
-    internal readonly Subject<PingRequest> PingMessageSubject = new();
-    internal readonly Subject<AccountErrorMessage> AccountErrorMessageSubject = new();
-    internal readonly Subject<AccountPingRequest> AccountPingMessageSubject = new();
-
-    public IObservable<ReconnectionInfo> ReconnectionInfoStream => ReconnectionInfoSubject.AsObservable();
-    public IObservable<DisconnectionInfo> DisconnectionInfoStream => DisconnectionInfoSubject.AsObservable();
-    public IObservable<string> UnhandledMessageStream => UnhandledMessageSubject.AsObservable();
-    public IObservable<ErrorMessage> ErrorMessageStream => ErrorMessageSubject.AsObservable();
-    public IObservable<PingRequest> PingMessageStream => PingMessageSubject.AsObservable();
-    public IObservable<AccountErrorMessage> AccountErrorMessageStream => AccountErrorMessageSubject.AsObservable();
-    public IObservable<AccountPingRequest> AccountPingMessageStream => AccountPingMessageSubject.AsObservable();
+    public readonly Subject<ReconnectionInfo> ReconnectionInfoStream = new();
+    public readonly Subject<DisconnectionInfo> DisconnectionInfoStream = new();
+    public readonly Subject<string> UnhandledMessageStream = new();
+    public readonly Subject<ErrorMessage> ErrorMessageStream = new();
+    public readonly Subject<PingRequest> PingMessageStream = new();
+    public readonly Subject<AccountErrorMessage> AccountErrorMessageStream = new();
+    public readonly Subject<AccountPingRequest> AccountPingMessageStream = new();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiClientStreamsBase.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiClientStreamsBase.cs
@@ -6,24 +6,23 @@ using Huobi.Client.Websocket.Messages.MarketData;
 using Websocket.Client;
 using Websocket.Client.Models;
 
-namespace Huobi.Client.Websocket.Clients.Streams
-{
-    public class HuobiClientStreamsBase
-    {
-        internal readonly Subject<ReconnectionInfo> ReconnectionInfoSubject = new();
-        internal readonly Subject<DisconnectionInfo> DisconnectionInfoSubject = new();
-        internal readonly Subject<string> UnhandledMessageSubject = new();
-        internal readonly Subject<ErrorMessage> ErrorMessageSubject = new();
-        internal readonly Subject<PingRequest> PingMessageSubject = new();
-        internal readonly Subject<AccountErrorMessage> AccountErrorMessageSubject = new();
-        internal readonly Subject<AccountPingRequest> AccountPingMessageSubject = new();
+namespace Huobi.Client.Websocket.Clients.Streams;
 
-        public IObservable<ReconnectionInfo> ReconnectionInfoStream => ReconnectionInfoSubject.AsObservable();
-        public IObservable<DisconnectionInfo> DisconnectionInfoStream => DisconnectionInfoSubject.AsObservable();
-        public IObservable<string> UnhandledMessageStream => UnhandledMessageSubject.AsObservable();
-        public IObservable<ErrorMessage> ErrorMessageStream => ErrorMessageSubject.AsObservable();
-        public IObservable<PingRequest> PingMessageStream => PingMessageSubject.AsObservable();
-        public IObservable<AccountErrorMessage> AccountErrorMessageStream => AccountErrorMessageSubject.AsObservable();
-        public IObservable<AccountPingRequest> AccountPingMessageStream => AccountPingMessageSubject.AsObservable();
-    }
+public class HuobiClientStreamsBase
+{
+    internal readonly Subject<ReconnectionInfo> ReconnectionInfoSubject = new();
+    internal readonly Subject<DisconnectionInfo> DisconnectionInfoSubject = new();
+    internal readonly Subject<string> UnhandledMessageSubject = new();
+    internal readonly Subject<ErrorMessage> ErrorMessageSubject = new();
+    internal readonly Subject<PingRequest> PingMessageSubject = new();
+    internal readonly Subject<AccountErrorMessage> AccountErrorMessageSubject = new();
+    internal readonly Subject<AccountPingRequest> AccountPingMessageSubject = new();
+
+    public IObservable<ReconnectionInfo> ReconnectionInfoStream => ReconnectionInfoSubject.AsObservable();
+    public IObservable<DisconnectionInfo> DisconnectionInfoStream => DisconnectionInfoSubject.AsObservable();
+    public IObservable<string> UnhandledMessageStream => UnhandledMessageSubject.AsObservable();
+    public IObservable<ErrorMessage> ErrorMessageStream => ErrorMessageSubject.AsObservable();
+    public IObservable<PingRequest> PingMessageStream => PingMessageSubject.AsObservable();
+    public IObservable<AccountErrorMessage> AccountErrorMessageStream => AccountErrorMessageSubject.AsObservable();
+    public IObservable<AccountPingRequest> AccountPingMessageStream => AccountPingMessageSubject.AsObservable();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiGenericClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiGenericClientStreams.cs
@@ -2,11 +2,10 @@
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
-namespace Huobi.Client.Websocket.Clients.Streams
+namespace Huobi.Client.Websocket.Clients.Streams;
+
+public class HuobiGenericClientStreams : HuobiClientStreamsBase
 {
-    public class HuobiGenericClientStreams : HuobiClientStreamsBase
-    {
-        internal readonly Subject<string> ResponseMessageSubject = new();
-        public IObservable<string> ResponseMessageStream => ResponseMessageSubject.AsObservable();
-    }
+    internal readonly Subject<string> ResponseMessageSubject = new();
+    public IObservable<string> ResponseMessageStream => ResponseMessageSubject.AsObservable();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiGenericClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiGenericClientStreams.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+﻿using System.Reactive.Subjects;
 
 namespace Huobi.Client.Websocket.Clients.Streams;
 
 public class HuobiGenericClientStreams : HuobiClientStreamsBase
 {
-    internal readonly Subject<string> ResponseMessageSubject = new();
-    public IObservable<string> ResponseMessageStream => ResponseMessageSubject.AsObservable();
+    public readonly Subject<string> ResponseMessageStream = new();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketByPriceClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketByPriceClientStreams.cs
@@ -4,20 +4,19 @@ using System.Reactive.Subjects;
 using Huobi.Client.Websocket.Messages.MarketData;
 using Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
 
-namespace Huobi.Client.Websocket.Clients.Streams
+namespace Huobi.Client.Websocket.Clients.Streams;
+
+public class HuobiMarketByPriceClientStreams : HuobiClientStreamsBase
 {
-    public class HuobiMarketByPriceClientStreams : HuobiClientStreamsBase
-    {
-        internal readonly Subject<SubscribeResponse> SubscribeResponseSubject = new();
-        internal readonly Subject<UnsubscribeResponse> UnsubscribeResponseSubject = new();
+    internal readonly Subject<SubscribeResponse> SubscribeResponseSubject = new();
+    internal readonly Subject<UnsubscribeResponse> UnsubscribeResponseSubject = new();
         
-        internal readonly Subject<MarketByPriceUpdateMessage> MarketByPriceUpdateSubject = new();
-        internal readonly Subject<MarketByPricePullResponse> MarketByPricePullSubject = new();
+    internal readonly Subject<MarketByPriceUpdateMessage> MarketByPriceUpdateSubject = new();
+    internal readonly Subject<MarketByPricePullResponse> MarketByPricePullSubject = new();
         
-        public IObservable<SubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
-        public IObservable<UnsubscribeResponse> UnsubscribeResponseStream => UnsubscribeResponseSubject.AsObservable();
+    public IObservable<SubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
+    public IObservable<UnsubscribeResponse> UnsubscribeResponseStream => UnsubscribeResponseSubject.AsObservable();
         
-        public IObservable<MarketByPriceUpdateMessage> MarketByPriceUpdateStream => MarketByPriceUpdateSubject.AsObservable();
-        public IObservable<MarketByPricePullResponse> MarketByPricePullStream => MarketByPricePullSubject.AsObservable();
-    }
+    public IObservable<MarketByPriceUpdateMessage> MarketByPriceUpdateStream => MarketByPriceUpdateSubject.AsObservable();
+    public IObservable<MarketByPricePullResponse> MarketByPricePullStream => MarketByPricePullSubject.AsObservable();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketByPriceClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketByPriceClientStreams.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+﻿using System.Reactive.Subjects;
 using Huobi.Client.Websocket.Messages.MarketData;
 using Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
 
@@ -8,15 +6,9 @@ namespace Huobi.Client.Websocket.Clients.Streams;
 
 public class HuobiMarketByPriceClientStreams : HuobiClientStreamsBase
 {
-    internal readonly Subject<SubscribeResponse> SubscribeResponseSubject = new();
-    internal readonly Subject<UnsubscribeResponse> UnsubscribeResponseSubject = new();
+    public readonly Subject<SubscribeResponse> SubscribeResponseStream = new();
+    public readonly Subject<UnsubscribeResponse> UnsubscribeResponseStream = new();
         
-    internal readonly Subject<MarketByPriceUpdateMessage> MarketByPriceUpdateSubject = new();
-    internal readonly Subject<MarketByPricePullResponse> MarketByPricePullSubject = new();
-        
-    public IObservable<SubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
-    public IObservable<UnsubscribeResponse> UnsubscribeResponseStream => UnsubscribeResponseSubject.AsObservable();
-        
-    public IObservable<MarketByPriceUpdateMessage> MarketByPriceUpdateStream => MarketByPriceUpdateSubject.AsObservable();
-    public IObservable<MarketByPricePullResponse> MarketByPricePullStream => MarketByPricePullSubject.AsObservable();
+    public readonly Subject<MarketByPriceUpdateMessage> MarketByPriceUpdateStream = new();
+    public readonly Subject<MarketByPricePullResponse> MarketByPricePullStream = new();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketClientStreams.cs
@@ -9,38 +9,37 @@ using Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
 using Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
 using Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
 
-namespace Huobi.Client.Websocket.Clients.Streams
+namespace Huobi.Client.Websocket.Clients.Streams;
+
+public class HuobiMarketClientStreams : HuobiClientStreamsBase
 {
-    public class HuobiMarketClientStreams : HuobiClientStreamsBase
-    {
-        internal readonly Subject<SubscribeResponse> SubscribeResponseSubject = new();
-        internal readonly Subject<UnsubscribeResponse> UnsubscribeResponseSubject = new();
+    internal readonly Subject<SubscribeResponse> SubscribeResponseSubject = new();
+    internal readonly Subject<UnsubscribeResponse> UnsubscribeResponseSubject = new();
 
-        internal readonly Subject<MarketCandlestickUpdateMessage> CandlestickUpdateSubject = new();
-        internal readonly Subject<MarketDepthUpdateMessage> DepthUpdateSubject = new();
-        internal readonly Subject<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateSubject = new();
-        internal readonly Subject<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateSubject = new();
-        internal readonly Subject<MarketTradeDetailUpdateMessage> TradeDetailUpdateSubject = new();
-        internal readonly Subject<MarketDetailsUpdateMessage> MarketDetailsUpdateSubject = new();
+    internal readonly Subject<MarketCandlestickUpdateMessage> CandlestickUpdateSubject = new();
+    internal readonly Subject<MarketDepthUpdateMessage> DepthUpdateSubject = new();
+    internal readonly Subject<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateSubject = new();
+    internal readonly Subject<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateSubject = new();
+    internal readonly Subject<MarketTradeDetailUpdateMessage> TradeDetailUpdateSubject = new();
+    internal readonly Subject<MarketDetailsUpdateMessage> MarketDetailsUpdateSubject = new();
 
-        internal readonly Subject<MarketCandlestickPullResponse> CandlestickPullSubject = new();
-        internal readonly Subject<MarketDepthPullResponse> DepthPullSubject = new();
-        internal readonly Subject<MarketTradeDetailPullResponse> TradeDetailPullSubject = new();
-        internal readonly Subject<MarketDetailsPullResponse> MarketDetailsPullSubject = new();
+    internal readonly Subject<MarketCandlestickPullResponse> CandlestickPullSubject = new();
+    internal readonly Subject<MarketDepthPullResponse> DepthPullSubject = new();
+    internal readonly Subject<MarketTradeDetailPullResponse> TradeDetailPullSubject = new();
+    internal readonly Subject<MarketDetailsPullResponse> MarketDetailsPullSubject = new();
 
-        public IObservable<SubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
-        public IObservable<UnsubscribeResponse> UnsubscribeResponseStream => UnsubscribeResponseSubject.AsObservable();
+    public IObservable<SubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
+    public IObservable<UnsubscribeResponse> UnsubscribeResponseStream => UnsubscribeResponseSubject.AsObservable();
 
-        public IObservable<MarketCandlestickUpdateMessage> CandlestickUpdateStream => CandlestickUpdateSubject.AsObservable();
-        public IObservable<MarketDepthUpdateMessage> DepthUpdateStream => DepthUpdateSubject.AsObservable();
-        public IObservable<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateStream => BestBidOfferUpdateSubject.AsObservable();
-        public IObservable<MarketTradeDetailUpdateMessage> TradeDetailUpdateStream => TradeDetailUpdateSubject.AsObservable();
-        public IObservable<MarketDetailsUpdateMessage> MarketDetailsUpdateStream => MarketDetailsUpdateSubject.AsObservable();
+    public IObservable<MarketCandlestickUpdateMessage> CandlestickUpdateStream => CandlestickUpdateSubject.AsObservable();
+    public IObservable<MarketDepthUpdateMessage> DepthUpdateStream => DepthUpdateSubject.AsObservable();
+    public IObservable<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateStream => BestBidOfferUpdateSubject.AsObservable();
+    public IObservable<MarketTradeDetailUpdateMessage> TradeDetailUpdateStream => TradeDetailUpdateSubject.AsObservable();
+    public IObservable<MarketDetailsUpdateMessage> MarketDetailsUpdateStream => MarketDetailsUpdateSubject.AsObservable();
 
-        public IObservable<MarketCandlestickPullResponse> CandlestickPullStream => CandlestickPullSubject.AsObservable();
-        public IObservable<MarketDepthPullResponse> DepthPullStream => DepthPullSubject.AsObservable();
-        public IObservable<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateStream => MarketByPriceRefreshUpdateSubject.AsObservable();
-        public IObservable<MarketTradeDetailPullResponse> TradeDetailPullStream => TradeDetailPullSubject.AsObservable();
-        public IObservable<MarketDetailsPullResponse> MarketDetailsPullStream => MarketDetailsPullSubject.AsObservable();
-    }
+    public IObservable<MarketCandlestickPullResponse> CandlestickPullStream => CandlestickPullSubject.AsObservable();
+    public IObservable<MarketDepthPullResponse> DepthPullStream => DepthPullSubject.AsObservable();
+    public IObservable<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateStream => MarketByPriceRefreshUpdateSubject.AsObservable();
+    public IObservable<MarketTradeDetailPullResponse> TradeDetailPullStream => TradeDetailPullSubject.AsObservable();
+    public IObservable<MarketDetailsPullResponse> MarketDetailsPullStream => MarketDetailsPullSubject.AsObservable();
 }

--- a/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketClientStreams.cs
+++ b/src/Huobi.Client.Websocket/Clients/Streams/HuobiMarketClientStreams.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+﻿using System.Reactive.Subjects;
 using Huobi.Client.Websocket.Messages.MarketData;
 using Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer;
 using Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
@@ -13,33 +11,18 @@ namespace Huobi.Client.Websocket.Clients.Streams;
 
 public class HuobiMarketClientStreams : HuobiClientStreamsBase
 {
-    internal readonly Subject<SubscribeResponse> SubscribeResponseSubject = new();
-    internal readonly Subject<UnsubscribeResponse> UnsubscribeResponseSubject = new();
+    public readonly Subject<SubscribeResponse> SubscribeResponseStream = new();
+    public readonly Subject<UnsubscribeResponse> UnsubscribeResponseStream = new();
 
-    internal readonly Subject<MarketCandlestickUpdateMessage> CandlestickUpdateSubject = new();
-    internal readonly Subject<MarketDepthUpdateMessage> DepthUpdateSubject = new();
-    internal readonly Subject<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateSubject = new();
-    internal readonly Subject<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateSubject = new();
-    internal readonly Subject<MarketTradeDetailUpdateMessage> TradeDetailUpdateSubject = new();
-    internal readonly Subject<MarketDetailsUpdateMessage> MarketDetailsUpdateSubject = new();
+    public readonly Subject<MarketCandlestickUpdateMessage> CandlestickUpdateStream = new();
+    public readonly Subject<MarketDepthUpdateMessage> DepthUpdateStream = new();
+    public readonly Subject<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateStream = new();
+    public readonly Subject<MarketTradeDetailUpdateMessage> TradeDetailUpdateStream = new();
+    public readonly Subject<MarketDetailsUpdateMessage> MarketDetailsUpdateStream = new();
 
-    internal readonly Subject<MarketCandlestickPullResponse> CandlestickPullSubject = new();
-    internal readonly Subject<MarketDepthPullResponse> DepthPullSubject = new();
-    internal readonly Subject<MarketTradeDetailPullResponse> TradeDetailPullSubject = new();
-    internal readonly Subject<MarketDetailsPullResponse> MarketDetailsPullSubject = new();
-
-    public IObservable<SubscribeResponse> SubscribeResponseStream => SubscribeResponseSubject.AsObservable();
-    public IObservable<UnsubscribeResponse> UnsubscribeResponseStream => UnsubscribeResponseSubject.AsObservable();
-
-    public IObservable<MarketCandlestickUpdateMessage> CandlestickUpdateStream => CandlestickUpdateSubject.AsObservable();
-    public IObservable<MarketDepthUpdateMessage> DepthUpdateStream => DepthUpdateSubject.AsObservable();
-    public IObservable<MarketBestBidOfferUpdateMessage> BestBidOfferUpdateStream => BestBidOfferUpdateSubject.AsObservable();
-    public IObservable<MarketTradeDetailUpdateMessage> TradeDetailUpdateStream => TradeDetailUpdateSubject.AsObservable();
-    public IObservable<MarketDetailsUpdateMessage> MarketDetailsUpdateStream => MarketDetailsUpdateSubject.AsObservable();
-
-    public IObservable<MarketCandlestickPullResponse> CandlestickPullStream => CandlestickPullSubject.AsObservable();
-    public IObservable<MarketDepthPullResponse> DepthPullStream => DepthPullSubject.AsObservable();
-    public IObservable<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateStream => MarketByPriceRefreshUpdateSubject.AsObservable();
-    public IObservable<MarketTradeDetailPullResponse> TradeDetailPullStream => TradeDetailPullSubject.AsObservable();
-    public IObservable<MarketDetailsPullResponse> MarketDetailsPullStream => MarketDetailsPullSubject.AsObservable();
+    public readonly Subject<MarketCandlestickPullResponse> CandlestickPullStream = new();
+    public readonly Subject<MarketDepthPullResponse> DepthPullStream = new();
+    public readonly Subject<MarketByPriceRefreshUpdateMessage> MarketByPriceRefreshUpdateStream = new();
+    public readonly Subject<MarketTradeDetailPullResponse> TradeDetailPullStream = new();
+    public readonly Subject<MarketDetailsPullResponse> MarketDetailsPullStream = new();
 }

--- a/src/Huobi.Client.Websocket/Communicator/HuobiAccountWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/HuobiAccountWebsocketCommunicator.cs
@@ -1,13 +1,12 @@
 ﻿using Huobi.Client.Websocket.Config;
 using Microsoft.Extensions.Options;
 
-namespace Huobi.Client.Websocket.Communicator
+namespace Huobi.Client.Websocket.Communicator;
+
+public class HuobiAccountWebsocketCommunicator : HuobiGenericWebsocketCommunicator, IHuobiAccountWebsocketCommunicator
 {
-    public class HuobiAccountWebsocketCommunicator : HuobiGenericWebsocketCommunicator, IHuobiAccountWebsocketCommunicator
+    public HuobiAccountWebsocketCommunicator(IOptions<HuobiAccountWebsocketClientConfig> config)
+        : base(config)
     {
-        public HuobiAccountWebsocketCommunicator(IOptions<HuobiAccountWebsocketClientConfig> config)
-            : base(config)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Communicator/HuobiGenericWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/HuobiGenericWebsocketCommunicator.cs
@@ -4,34 +4,33 @@ using Huobi.Client.Websocket.Utils;
 using Microsoft.Extensions.Options;
 using Websocket.Client;
 
-namespace Huobi.Client.Websocket.Communicator
+namespace Huobi.Client.Websocket.Communicator;
+
+public class HuobiGenericWebsocketCommunicator : WebsocketClient, IHuobiGenericWebsocketCommunicator
 {
-    public class HuobiGenericWebsocketCommunicator : WebsocketClient, IHuobiGenericWebsocketCommunicator
+    public HuobiGenericWebsocketCommunicator(IOptions<HuobiGenericWebsocketClientConfig> config)
+        : this(config.Value)
     {
-        public HuobiGenericWebsocketCommunicator(IOptions<HuobiGenericWebsocketClientConfig> config)
-            : this(config.Value)
+    }
+
+    protected HuobiGenericWebsocketCommunicator(HuobiGenericWebsocketClientConfig config)
+        : base(GetUri(config))
+    {
+        Validations.ValidateInput(config, nameof(config));
+
+        Name = config.CommunicatorName ?? "Huobi";
+
+        if (config.ReconnectTimeoutMin.HasValue)
         {
+            ReconnectTimeout = TimeSpan.FromMinutes(config.ReconnectTimeoutMin.Value);
         }
+    }
 
-        protected HuobiGenericWebsocketCommunicator(HuobiGenericWebsocketClientConfig config)
-            : base(GetUri(config))
-        {
-            Validations.ValidateInput(config, nameof(config));
+    private static Uri GetUri(HuobiGenericWebsocketClientConfig config)
+    {
+        Validations.ValidateInput(config, nameof(config));
+        Validations.ValidateInput(config.Url, nameof(config.Url));
 
-            Name = config.CommunicatorName ?? "Huobi";
-
-            if (config.ReconnectTimeoutMin.HasValue)
-            {
-                ReconnectTimeout = TimeSpan.FromMinutes(config.ReconnectTimeoutMin.Value);
-            }
-        }
-
-        private static Uri GetUri(HuobiGenericWebsocketClientConfig config)
-        {
-            Validations.ValidateInput(config, nameof(config));
-            Validations.ValidateInput(config.Url, nameof(config.Url));
-
-            return new Uri(config.Url!);
-        }
+        return new Uri(config.Url!);
     }
 }

--- a/src/Huobi.Client.Websocket/Communicator/HuobiMarketByPriceWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/HuobiMarketByPriceWebsocketCommunicator.cs
@@ -1,13 +1,12 @@
 ﻿using Huobi.Client.Websocket.Config;
 using Microsoft.Extensions.Options;
 
-namespace Huobi.Client.Websocket.Communicator
+namespace Huobi.Client.Websocket.Communicator;
+
+public class HuobiMarketByPriceWebsocketCommunicator : HuobiGenericWebsocketCommunicator, IHuobiMarketByPriceWebsocketCommunicator
 {
-    public class HuobiMarketByPriceWebsocketCommunicator : HuobiGenericWebsocketCommunicator, IHuobiMarketByPriceWebsocketCommunicator
+    public HuobiMarketByPriceWebsocketCommunicator(IOptions<HuobiMarketByPriceWebsocketClientConfig> config)
+        : base(config)
     {
-        public HuobiMarketByPriceWebsocketCommunicator(IOptions<HuobiMarketByPriceWebsocketClientConfig> config)
-            : base(config)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Communicator/HuobiMarketWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/HuobiMarketWebsocketCommunicator.cs
@@ -1,13 +1,12 @@
 ﻿using Huobi.Client.Websocket.Config;
 using Microsoft.Extensions.Options;
 
-namespace Huobi.Client.Websocket.Communicator
+namespace Huobi.Client.Websocket.Communicator;
+
+public class HuobiMarketWebsocketCommunicator : HuobiGenericWebsocketCommunicator, IHuobiMarketWebsocketCommunicator
 {
-    public class HuobiMarketWebsocketCommunicator : HuobiGenericWebsocketCommunicator, IHuobiMarketWebsocketCommunicator
+    public HuobiMarketWebsocketCommunicator(IOptions<HuobiMarketWebsocketClientConfig> config)
+        : base(config)
     {
-        public HuobiMarketWebsocketCommunicator(IOptions<HuobiMarketWebsocketClientConfig> config)
-            : base(config)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Communicator/IHuobiAccountWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/IHuobiAccountWebsocketCommunicator.cs
@@ -1,6 +1,5 @@
-﻿namespace Huobi.Client.Websocket.Communicator
+﻿namespace Huobi.Client.Websocket.Communicator;
+
+public interface IHuobiAccountWebsocketCommunicator : IHuobiGenericWebsocketCommunicator
 {
-    public interface IHuobiAccountWebsocketCommunicator : IHuobiGenericWebsocketCommunicator
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Communicator/IHuobiGenericWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/IHuobiGenericWebsocketCommunicator.cs
@@ -1,8 +1,7 @@
 ﻿using Websocket.Client;
 
-namespace Huobi.Client.Websocket.Communicator
+namespace Huobi.Client.Websocket.Communicator;
+
+public interface IHuobiGenericWebsocketCommunicator : IWebsocketClient
 {
-    public interface IHuobiGenericWebsocketCommunicator : IWebsocketClient
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Communicator/IHuobiMarketByPriceWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/IHuobiMarketByPriceWebsocketCommunicator.cs
@@ -1,6 +1,5 @@
-﻿namespace Huobi.Client.Websocket.Communicator
+﻿namespace Huobi.Client.Websocket.Communicator;
+
+public interface IHuobiMarketByPriceWebsocketCommunicator : IHuobiGenericWebsocketCommunicator
 {
-    public interface IHuobiMarketByPriceWebsocketCommunicator : IHuobiGenericWebsocketCommunicator
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Communicator/IHuobiMarketWebsocketCommunicator.cs
+++ b/src/Huobi.Client.Websocket/Communicator/IHuobiMarketWebsocketCommunicator.cs
@@ -1,6 +1,5 @@
-﻿namespace Huobi.Client.Websocket.Communicator
+﻿namespace Huobi.Client.Websocket.Communicator;
+
+public interface IHuobiMarketWebsocketCommunicator : IHuobiGenericWebsocketCommunicator
 {
-    public interface IHuobiMarketWebsocketCommunicator : IHuobiGenericWebsocketCommunicator
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Config/HuobiAccountWebsocketClientConfig.cs
+++ b/src/Huobi.Client.Websocket/Config/HuobiAccountWebsocketClientConfig.cs
@@ -1,8 +1,7 @@
-﻿namespace Huobi.Client.Websocket.Config
+﻿namespace Huobi.Client.Websocket.Config;
+
+public class HuobiAccountWebsocketClientConfig : HuobiGenericWebsocketClientConfig
 {
-    public class HuobiAccountWebsocketClientConfig : HuobiGenericWebsocketClientConfig
-    {
-        public string? AccessKey { get; set; }
-        public string? SecretKey { get; set; }
-    }
+    public string? AccessKey { get; set; }
+    public string? SecretKey { get; set; }
 }

--- a/src/Huobi.Client.Websocket/Config/HuobiGenericWebsocketClientConfig.cs
+++ b/src/Huobi.Client.Websocket/Config/HuobiGenericWebsocketClientConfig.cs
@@ -1,9 +1,8 @@
-﻿namespace Huobi.Client.Websocket.Config
+﻿namespace Huobi.Client.Websocket.Config;
+
+public class HuobiGenericWebsocketClientConfig
 {
-    public class HuobiGenericWebsocketClientConfig
-    {
-        public string? Url { get; set; }
-        public string? CommunicatorName { get; set; }
-        public int? ReconnectTimeoutMin { get; set; }
-    }
+    public string? Url { get; set; }
+    public string? CommunicatorName { get; set; }
+    public int? ReconnectTimeoutMin { get; set; }
 }

--- a/src/Huobi.Client.Websocket/Config/HuobiMarketByPriceWebsocketClientConfig.cs
+++ b/src/Huobi.Client.Websocket/Config/HuobiMarketByPriceWebsocketClientConfig.cs
@@ -1,6 +1,5 @@
-﻿namespace Huobi.Client.Websocket.Config
+﻿namespace Huobi.Client.Websocket.Config;
+
+public class HuobiMarketByPriceWebsocketClientConfig : HuobiGenericWebsocketClientConfig
 {
-    public class HuobiMarketByPriceWebsocketClientConfig : HuobiGenericWebsocketClientConfig
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Config/HuobiMarketWebsocketClientConfig.cs
+++ b/src/Huobi.Client.Websocket/Config/HuobiMarketWebsocketClientConfig.cs
@@ -1,6 +1,5 @@
-﻿namespace Huobi.Client.Websocket.Config
+﻿namespace Huobi.Client.Websocket.Config;
+
+public class HuobiMarketWebsocketClientConfig : HuobiGenericWebsocketClientConfig
 {
-    public class HuobiMarketWebsocketClientConfig : HuobiGenericWebsocketClientConfig
-    {
-    }
 }

--- a/src/Huobi.Client.Websocket/Huobi.Client.Websocket.csproj
+++ b/src/Huobi.Client.Websocket/Huobi.Client.Websocket.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net5;net6</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>

--- a/src/Huobi.Client.Websocket/Huobi.Client.Websocket.csproj
+++ b/src/Huobi.Client.Websocket/Huobi.Client.Websocket.csproj
@@ -11,12 +11,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Websocket.Client" Version="4.3.30" />
+    <PackageReference Include="Websocket.Client" Version="4.4.43" />
   </ItemGroup>
 
 </Project>

--- a/src/Huobi.Client.Websocket/HuobiConstants.cs
+++ b/src/Huobi.Client.Websocket/HuobiConstants.cs
@@ -1,14 +1,13 @@
-﻿namespace Huobi.Client.Websocket
+﻿namespace Huobi.Client.Websocket;
+
+public class HuobiConstants
 {
-    public class HuobiConstants
-    {
-        public const string ApiWebsocketUrl = "wss://api.huobi.pro/ws";
-        public const string AwsApiWebsocketUrl = "wss://api-aws.huobi.pro/ws";
-        public const string ApiMbpWebsocketUrl = "wss://api.huobi.pro/feed";
-        public const string AwsApiMpbWebsocketUrl = "wss://api-aws.huobi.pro/feed";
-        public const string ApiAccountWebsocketUrl = "wss://api.huobi.pro/ws/v2";
-        public const string AwsApiAccountWebsocketUrl = "wss://api-aws.huobi.pro/ws/v2";
+    public const string ApiWebsocketUrl = "wss://api.huobi.pro/ws";
+    public const string AwsApiWebsocketUrl = "wss://api-aws.huobi.pro/ws";
+    public const string ApiMbpWebsocketUrl = "wss://api.huobi.pro/feed";
+    public const string AwsApiMpbWebsocketUrl = "wss://api-aws.huobi.pro/feed";
+    public const string ApiAccountWebsocketUrl = "wss://api.huobi.pro/ws/v2";
+    public const string AwsApiAccountWebsocketUrl = "wss://api-aws.huobi.pro/ws/v2";
         
-        internal static readonly string MARKET_PREFIX = "market";
-    }
+    internal static readonly string MARKET_PREFIX = "market";
 }

--- a/src/Huobi.Client.Websocket/HuobiWebsocketClientException.cs
+++ b/src/Huobi.Client.Websocket/HuobiWebsocketClientException.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket
+namespace Huobi.Client.Websocket;
+
+public class HuobiWebsocketClientException : Exception
 {
-    public class HuobiWebsocketClientException : Exception
+    public HuobiWebsocketClientException(string message)
+        : base(message)
     {
-        public HuobiWebsocketClientException(string message)
-            : base(message)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountErrorMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountErrorMessage.cs
@@ -2,40 +2,39 @@
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public class AccountErrorMessage
 {
-    public class AccountErrorMessage
+    [JsonConstructor]
+    public AccountErrorMessage(int code, string? topic, string? message)
     {
-        [JsonConstructor]
-        public AccountErrorMessage(int code, string? topic, string? message)
-        {
-            Code = code;
-            Topic = topic ?? string.Empty;
-            Message = message ?? string.Empty;
-        }
+        Code = code;
+        Topic = topic ?? string.Empty;
+        Message = message ?? string.Empty;
+    }
 
-        public int Code { get; }
+    public int Code { get; }
 
-        [JsonProperty("ch")]
-        public string Topic { get; }
+    [JsonProperty("ch")]
+    public string Topic { get; }
 
-        public string Message { get; }
+    public string Message { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out AccountErrorMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"code\"",
-                    "\"message\""
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out AccountErrorMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"code\"",
+                "\"message\""
+            },
+            out response);
 
-            return result && response?.Code != 200;
-        }
+        return result && response?.Code != 200;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountMessageData.cs
@@ -1,16 +1,15 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public class AccountMessageData
 {
-    public class AccountMessageData
+    public AccountMessageData(DateTimeOffset timestamp)
     {
-        public AccountMessageData(DateTimeOffset timestamp)
-        {
-            Timestamp = timestamp;
-        }
-        
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
+        Timestamp = timestamp;
     }
+        
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountPingRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountPingRequest.cs
@@ -3,42 +3,41 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public class AccountPingRequest
 {
-    public class AccountPingRequest
+    public AccountPingRequest(DateTimeOffset timestamp)
+        : this("ping", new AccountMessageData(timestamp))
     {
-        public AccountPingRequest(DateTimeOffset timestamp)
-            : this("ping", new AccountMessageData(timestamp))
-        {
-        }
+    }
 
-        [JsonConstructor]
-        internal AccountPingRequest(string? action, AccountMessageData? data)
-        {
-            Action = action ?? string.Empty;
-            Data = data;
-        }
+    [JsonConstructor]
+    internal AccountPingRequest(string? action, AccountMessageData? data)
+    {
+        Action = action ?? string.Empty;
+        Data = data;
+    }
 
-        [JsonProperty("action")]
-        public string Action { get; }
+    [JsonProperty("action")]
+    public string Action { get; }
 
-        [JsonProperty("data")]
-        public AccountMessageData? Data { get; }
+    [JsonProperty("data")]
+    public AccountMessageData? Data { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out AccountPingRequest response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"ping\""
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out AccountPingRequest response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"ping\""
+            },
+            out response);
 
-            return result && string.Equals(response?.Action, "ping");
-        }
+        return result && string.Equals(response?.Action, "ping");
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountPongResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountPongResponse.cs
@@ -1,20 +1,19 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
-{
-    public class AccountPongResponse
-    {
-        public AccountPongResponse(DateTimeOffset timestamp)
-        {
-            Action = "pong";
-            Data = new AccountMessageData(timestamp);
-        }
+namespace Huobi.Client.Websocket.Messages.Account;
 
-        [JsonProperty("action")]
-        public string Action { get; }
-        
-        [JsonProperty("data")]
-        public AccountMessageData Data { get; }
+public class AccountPongResponse
+{
+    public AccountPongResponse(DateTimeOffset timestamp)
+    {
+        Action = "pong";
+        Data = new AccountMessageData(timestamp);
     }
+
+    [JsonProperty("action")]
+    public string Action { get; }
+        
+    [JsonProperty("data")]
+    public AccountMessageData Data { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountRequestBase.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountRequestBase.cs
@@ -1,23 +1,22 @@
 ﻿using Huobi.Client.Websocket.Utils;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public abstract class AccountRequestBase
 {
-    public abstract class AccountRequestBase
+    protected AccountRequestBase(string action, string channel)
     {
-        protected AccountRequestBase(string action, string channel)
-        {
-            Validations.ValidateInput(action, nameof(action));
-            Validations.ValidateInput(channel, nameof(channel));
+        Validations.ValidateInput(action, nameof(action));
+        Validations.ValidateInput(channel, nameof(channel));
 
-            Action = action;
-            Channel = channel;
-        }
-
-        [JsonProperty("action")]
-        public string Action { get; }
-
-        [JsonProperty("ch")]
-        public string Channel { get; }
+        Action = action;
+        Channel = channel;
     }
+
+    [JsonProperty("action")]
+    public string Action { get; }
+
+    [JsonProperty("ch")]
+    public string Channel { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountRequestParams.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountRequestParams.cs
@@ -3,39 +3,38 @@ using Huobi.Client.Websocket.Authentication;
 using Huobi.Client.Websocket.Utils;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public class AccountRequestParams
 {
-    public class AccountRequestParams
+    public AccountRequestParams(string accessKey, string signature, DateTimeOffset timestamp)
     {
-        public AccountRequestParams(string accessKey, string signature, DateTimeOffset timestamp)
-        {
-            Validations.ValidateInput(accessKey, nameof(accessKey));
-            Validations.ValidateInput(signature, nameof(signature));
+        Validations.ValidateInput(accessKey, nameof(accessKey));
+        Validations.ValidateInput(signature, nameof(signature));
 
-            AuthType = "api";
-            AccessKey = accessKey;
-            SignatureMethod = HuobiSignature.SIGNATURE_METHOD_VALUE;
-            SignatureVersion = HuobiSignature.SIGNATURE_VERSION_VERSION;
-            Timestamp = timestamp.ToHuobiUtcString();
-            Signature = signature;
-        }
-
-        [JsonProperty("authType")]
-        public string AuthType { get; }
-
-        [JsonProperty("accessKey")]
-        public string AccessKey { get; }
-
-        [JsonProperty("signatureMethod")]
-        public string SignatureMethod { get; }
-
-        [JsonProperty("signatureVersion")]
-        public string SignatureVersion { get; }
-
-        [JsonProperty("timestamp")]
-        public string Timestamp { get; }
-
-        [JsonProperty("signature")]
-        public string Signature { get; }
+        AuthType = "api";
+        AccessKey = accessKey;
+        SignatureMethod = HuobiSignature.SIGNATURE_METHOD_VALUE;
+        SignatureVersion = HuobiSignature.SIGNATURE_VERSION_VERSION;
+        Timestamp = timestamp.ToHuobiUtcString();
+        Signature = signature;
     }
+
+    [JsonProperty("authType")]
+    public string AuthType { get; }
+
+    [JsonProperty("accessKey")]
+    public string AccessKey { get; }
+
+    [JsonProperty("signatureMethod")]
+    public string SignatureMethod { get; }
+
+    [JsonProperty("signatureVersion")]
+    public string SignatureVersion { get; }
+
+    [JsonProperty("timestamp")]
+    public string Timestamp { get; }
+
+    [JsonProperty("signature")]
+    public string Signature { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountResponseBase.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountResponseBase.cs
@@ -1,22 +1,21 @@
 ﻿using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public abstract class AccountResponseBase<TData>
+    where TData : class
 {
-    public abstract class AccountResponseBase<TData>
-        where TData : class
+    protected AccountResponseBase(string? action, string? channel, TData? data)
     {
-        protected AccountResponseBase(string? action, string? channel, TData? data)
-        {
-            Action = action ?? string.Empty;
-            Channel = channel ?? string.Empty;
-            Data = data;
-        }
-
-        public string Action { get; }
-
-        [JsonProperty("ch")]
-        public string Channel { get; }
-
-        public TData? Data { get; }
+        Action = action ?? string.Empty;
+        Channel = channel ?? string.Empty;
+        Data = data;
     }
+
+    public string Action { get; }
+
+    [JsonProperty("ch")]
+    public string Channel { get; }
+
+    public TData? Data { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountSubscribeRequest.cs
@@ -1,17 +1,16 @@
 ﻿using Huobi.Client.Websocket.Messages.Account.Values;
 
-namespace Huobi.Client.Websocket.Messages.Account
-{
-    public class AccountSubscribeRequest : AccountRequestBase
-    {
-        public AccountSubscribeRequest(string symbol, AccountSubscriptionType subscriptionType)
-            : base("sub", FormatChannel(symbol, subscriptionType))
-        {
-        }
+namespace Huobi.Client.Websocket.Messages.Account;
 
-        private static string FormatChannel(string symbol, AccountSubscriptionType subscriptionType)
-        {
-            return $"{subscriptionType.ToTopicId()}#{symbol}";
-        }
+public class AccountSubscribeRequest : AccountRequestBase
+{
+    public AccountSubscribeRequest(string symbol, AccountSubscriptionType subscriptionType)
+        : base("sub", FormatChannel(symbol, subscriptionType))
+    {
+    }
+
+    private static string FormatChannel(string symbol, AccountSubscriptionType subscriptionType)
+    {
+        return $"{subscriptionType.ToTopicId()}#{symbol}";
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountSubscribeResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountSubscribeResponse.cs
@@ -2,38 +2,37 @@
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public class AccountSubscribeResponse : AccountResponseBase<object>
 {
-    public class AccountSubscribeResponse : AccountResponseBase<object>
+    [JsonConstructor]
+    public AccountSubscribeResponse(string action, int code, string channel, object data)
+        : base(action, channel, data)
     {
-        [JsonConstructor]
-        public AccountSubscribeResponse(string action, int code, string channel, object data)
-            : base(action, channel, data)
-        {
-            Code = code;
-        }
+        Code = code;
+    }
 
-        public int Code { get; }
+    public int Code { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out AccountSubscribeResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"sub\"",
-                    "\"code\""
-                },
-                new[]
-                {
-                    "\"message\""
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out AccountSubscribeResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"sub\"",
+                "\"code\""
+            },
+            new[]
+            {
+                "\"message\""
+            },
+            out response);
 
-            return result;
-        }
+        return result;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountUpdates/AccountUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountUpdates/AccountUpdateMessage.cs
@@ -2,27 +2,26 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.Account.AccountUpdates
+namespace Huobi.Client.Websocket.Messages.Account.AccountUpdates;
+
+public class AccountUpdateMessage : AccountResponseBase<AccountUpdateMessageData>
 {
-    public class AccountUpdateMessage : AccountResponseBase<AccountUpdateMessageData>
+    public AccountUpdateMessage(string action, string channel, AccountUpdateMessageData data)
+        : base(action, channel, data)
     {
-        public AccountUpdateMessage(string action, string channel, AccountUpdateMessageData data)
-            : base(action, channel, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out AccountUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                AccountSubscriptionType.AccountUpdates.ToTopicId(),
-                "\"code\"",
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out AccountUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            AccountSubscriptionType.AccountUpdates.ToTopicId(),
+            "\"code\"",
+            out response);
 
-            return result && response?.Data?.ChangeTime.Ticks > 0;
-        }
+        return result && response?.Data?.ChangeTime.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountUpdates/AccountUpdateMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountUpdates/AccountUpdateMessageData.cs
@@ -2,35 +2,34 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.AccountUpdates
-{
-    public class AccountUpdateMessageData
-    {
-        [JsonConstructor]
-        public AccountUpdateMessageData(
-            string currency,
-            long accountId,
-            decimal balance,
-            decimal available,
-            AccountChangeType changeType,
-            AccountType accountType,
-            DateTimeOffset changeTime)
-        {
-            Currency = currency;
-            AccountId = accountId;
-            Balance = balance;
-            Available = available;
-            ChangeType = changeType;
-            AccountType = accountType;
-            ChangeTime = changeTime;
-        }
+namespace Huobi.Client.Websocket.Messages.Account.AccountUpdates;
 
-        public string Currency { get; }
-        public long AccountId { get; }
-        public decimal Balance { get; }
-        public decimal Available { get; }
-        public AccountChangeType ChangeType { get; }
-        public AccountType AccountType { get; }
-        public DateTimeOffset ChangeTime { get; }
+public class AccountUpdateMessageData
+{
+    [JsonConstructor]
+    public AccountUpdateMessageData(
+        string currency,
+        long accountId,
+        decimal balance,
+        decimal available,
+        AccountChangeType changeType,
+        AccountType accountType,
+        DateTimeOffset changeTime)
+    {
+        Currency = currency;
+        AccountId = accountId;
+        Balance = balance;
+        Available = available;
+        ChangeType = changeType;
+        AccountType = accountType;
+        ChangeTime = changeTime;
     }
+
+    public string Currency { get; }
+    public long AccountId { get; }
+    public decimal Balance { get; }
+    public decimal Available { get; }
+    public AccountChangeType ChangeType { get; }
+    public AccountType AccountType { get; }
+    public DateTimeOffset ChangeTime { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AccountUpdates/AccountUpdateSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AccountUpdates/AccountUpdateSubscribeRequest.cs
@@ -1,17 +1,16 @@
 ﻿using Huobi.Client.Websocket.Messages.Account.Values;
 
-namespace Huobi.Client.Websocket.Messages.Account.AccountUpdates
-{
-    public class AccountUpdateSubscribeRequest : AccountSubscribeRequest
-    {
-        public AccountUpdateSubscribeRequest(bool withAvailableBalanceChanges = false)
-            : base(FormatSymbol(withAvailableBalanceChanges), AccountSubscriptionType.AccountUpdates)
-        {
-        }
+namespace Huobi.Client.Websocket.Messages.Account.AccountUpdates;
 
-        private static string FormatSymbol(bool withAvailableBalanceChanges)
-        {
-            return withAvailableBalanceChanges ? "1" : "0";
-        }
+public class AccountUpdateSubscribeRequest : AccountSubscribeRequest
+{
+    public AccountUpdateSubscribeRequest(bool withAvailableBalanceChanges = false)
+        : base(FormatSymbol(withAvailableBalanceChanges), AccountSubscriptionType.AccountUpdates)
+    {
+    }
+
+    private static string FormatSymbol(bool withAvailableBalanceChanges)
+    {
+        return withAvailableBalanceChanges ? "1" : "0";
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AuthenticationRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AuthenticationRequest.cs
@@ -1,17 +1,16 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
-{
-    public class AuthenticationRequest : AccountRequestBase
-    {
-        public AuthenticationRequest(string accessKey, string signature, DateTimeOffset timestamp)
-            : base("req", "auth")
-        {
-            Parameters = new AccountRequestParams(accessKey, signature, timestamp);
-        }
+namespace Huobi.Client.Websocket.Messages.Account;
 
-        [JsonProperty("params")]
-        public AccountRequestParams Parameters { get; }
+public class AuthenticationRequest : AccountRequestBase
+{
+    public AuthenticationRequest(string accessKey, string signature, DateTimeOffset timestamp)
+        : base("req", "auth")
+    {
+        Parameters = new AccountRequestParams(accessKey, signature, timestamp);
     }
+
+    [JsonProperty("params")]
+    public AccountRequestParams Parameters { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/AuthenticationResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/AuthenticationResponse.cs
@@ -2,34 +2,33 @@
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account
+namespace Huobi.Client.Websocket.Messages.Account;
+
+public class AuthenticationResponse : AccountResponseBase<object>
 {
-    public class AuthenticationResponse : AccountResponseBase<object>
+    [JsonConstructor]
+    public AuthenticationResponse(string action, int code, string channel, object data)
+        : base(action, channel, data)
     {
-        [JsonConstructor]
-        public AuthenticationResponse(string action, int code, string channel, object data)
-            : base(action, channel, data)
-        {
-            Code = code;
-        }
+        Code = code;
+    }
 
-        public int Code { get; }
+    public int Code { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out AuthenticationResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"req\"",
-                    "\"auth\""
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out AuthenticationResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"req\"",
+                "\"auth\""
+            },
+            out response);
 
-            return result;
-        }
+        return result;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderCanceledMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderCanceledMessage.cs
@@ -2,33 +2,32 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class ConditionalOrderCanceledMessage : AccountResponseBase<ConditionalOrderCanceledMessageData>
 {
-    public class ConditionalOrderCanceledMessage : AccountResponseBase<ConditionalOrderCanceledMessageData>
+    public ConditionalOrderCanceledMessage(
+        string action,
+        string channel,
+        ConditionalOrderCanceledMessageData data)
+        : base(action, channel, data)
     {
-        public ConditionalOrderCanceledMessage(
-            string action,
-            string channel,
-            ConditionalOrderCanceledMessageData data)
-            : base(action, channel, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out ConditionalOrderCanceledMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    AccountSubscriptionType.Orders.ToTopicId(),
-                    OrderEventType.Deletion.ToString().ToLower()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out ConditionalOrderCanceledMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                AccountSubscriptionType.Orders.ToTopicId(),
+                OrderEventType.Deletion.ToString().ToLower()
+            },
+            out response);
 
-            return result && response?.Data?.OrderTriggerTime.Ticks > 0;
-        }
+        return result && response?.Data?.OrderTriggerTime.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderCanceledMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderCanceledMessageData.cs
@@ -2,34 +2,33 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class ConditionalOrderCanceledMessageData
 {
-    public class ConditionalOrderCanceledMessageData
+    [JsonConstructor]
+    public ConditionalOrderCanceledMessageData(
+        OrderEventType eventType,
+        OrderStatus orderStatus,
+        string symbol,
+        string clientOrderId,
+        OrderSide orderSide,
+        DateTimeOffset orderTriggerTime)
     {
-        [JsonConstructor]
-        public ConditionalOrderCanceledMessageData(
-            OrderEventType eventType,
-            OrderStatus orderStatus,
-            string symbol,
-            string clientOrderId,
-            OrderSide orderSide,
-            DateTimeOffset orderTriggerTime)
-        {
-            EventType = eventType;
-            Symbol = symbol;
-            ClientOrderId = clientOrderId;
-            OrderSide = orderSide;
-            OrderStatus = orderStatus;
-            OrderTriggerTime = orderTriggerTime;
-        }
-
-        public OrderEventType EventType { get; }
-        public string Symbol { get; }
-        public string ClientOrderId { get; }
-        public OrderSide OrderSide { get; }
-        public OrderStatus OrderStatus { get; }
-
-        [JsonProperty("lastActTime")]
-        public DateTimeOffset OrderTriggerTime { get; }
+        EventType = eventType;
+        Symbol = symbol;
+        ClientOrderId = clientOrderId;
+        OrderSide = orderSide;
+        OrderStatus = orderStatus;
+        OrderTriggerTime = orderTriggerTime;
     }
+
+    public OrderEventType EventType { get; }
+    public string Symbol { get; }
+    public string ClientOrderId { get; }
+    public OrderSide OrderSide { get; }
+    public OrderStatus OrderStatus { get; }
+
+    [JsonProperty("lastActTime")]
+    public DateTimeOffset OrderTriggerTime { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderTriggerFailureMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderTriggerFailureMessage.cs
@@ -2,33 +2,32 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class ConditionalOrderTriggerFailureMessage : AccountResponseBase<ConditionalOrderTriggerFailureMessageData>
 {
-    public class ConditionalOrderTriggerFailureMessage : AccountResponseBase<ConditionalOrderTriggerFailureMessageData>
+    public ConditionalOrderTriggerFailureMessage(
+        string action,
+        string channel,
+        ConditionalOrderTriggerFailureMessageData data)
+        : base(action, channel, data)
     {
-        public ConditionalOrderTriggerFailureMessage(
-            string action,
-            string channel,
-            ConditionalOrderTriggerFailureMessageData data)
-            : base(action, channel, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out ConditionalOrderTriggerFailureMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    AccountSubscriptionType.Orders.ToTopicId(),
-                    OrderEventType.Trigger.ToString().ToLower()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out ConditionalOrderTriggerFailureMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                AccountSubscriptionType.Orders.ToTopicId(),
+                OrderEventType.Trigger.ToString().ToLower()
+            },
+            out response);
 
-            return result && response?.Data?.ErrorCode > 0;
-        }
+        return result && response?.Data?.ErrorCode > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderTriggerFailureMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/ConditionalOrderTriggerFailureMessageData.cs
@@ -2,44 +2,43 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class ConditionalOrderTriggerFailureMessageData
 {
-    public class ConditionalOrderTriggerFailureMessageData
+    [JsonConstructor]
+    public ConditionalOrderTriggerFailureMessageData(
+        OrderEventType eventType,
+        string symbol,
+        string clientOrderId,
+        OrderSide orderSide,
+        OrderStatus orderStatus,
+        int errorCode,
+        string errorMessage,
+        DateTimeOffset orderTriggeringFailureTime)
     {
-        [JsonConstructor]
-        public ConditionalOrderTriggerFailureMessageData(
-            OrderEventType eventType,
-            string symbol,
-            string clientOrderId,
-            OrderSide orderSide,
-            OrderStatus orderStatus,
-            int errorCode,
-            string errorMessage,
-            DateTimeOffset orderTriggeringFailureTime)
-        {
-            EventType = eventType;
-            Symbol = symbol;
-            ClientOrderId = clientOrderId;
-            OrderSide = orderSide;
-            OrderStatus = orderStatus;
-            ErrorCode = errorCode;
-            ErrorMessage = errorMessage;
-            OrderTriggeringFailureTime = orderTriggeringFailureTime;
-        }
-        
-        public OrderEventType EventType { get; }
-        public string Symbol { get; }
-        public string ClientOrderId { get; }
-        public OrderSide OrderSide { get; }
-        public OrderStatus OrderStatus { get; }
-
-        [JsonProperty("errCode")]
-        public int ErrorCode { get; }
-
-        [JsonProperty("errMessage")]
-        public string ErrorMessage { get; }
-
-        [JsonProperty("lastActTime")]
-        public DateTimeOffset OrderTriggeringFailureTime { get; }
+        EventType = eventType;
+        Symbol = symbol;
+        ClientOrderId = clientOrderId;
+        OrderSide = orderSide;
+        OrderStatus = orderStatus;
+        ErrorCode = errorCode;
+        ErrorMessage = errorMessage;
+        OrderTriggeringFailureTime = orderTriggeringFailureTime;
     }
+        
+    public OrderEventType EventType { get; }
+    public string Symbol { get; }
+    public string ClientOrderId { get; }
+    public OrderSide OrderSide { get; }
+    public OrderStatus OrderStatus { get; }
+
+    [JsonProperty("errCode")]
+    public int ErrorCode { get; }
+
+    [JsonProperty("errMessage")]
+    public string ErrorMessage { get; }
+
+    [JsonProperty("lastActTime")]
+    public DateTimeOffset OrderTriggeringFailureTime { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderCanceledMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderCanceledMessage.cs
@@ -2,30 +2,29 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class OrderCanceledMessage : AccountResponseBase<OrderCanceledMessageData>
 {
-    public class OrderCanceledMessage : AccountResponseBase<OrderCanceledMessageData>
+    public OrderCanceledMessage(string action, string channel, OrderCanceledMessageData data)
+        : base(action, channel, data)
     {
-        public OrderCanceledMessage(string action, string channel, OrderCanceledMessageData data)
-            : base(action, channel, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out OrderCanceledMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    AccountSubscriptionType.Orders.ToTopicId(),
-                    OrderEventType.Cancellation.ToString().ToLower()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out OrderCanceledMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                AccountSubscriptionType.Orders.ToTopicId(),
+                OrderEventType.Cancellation.ToString().ToLower()
+            },
+            out response);
 
-            return result && response?.Data?.OrderId > 0;
-        }
+        return result && response?.Data?.OrderId > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderCanceledMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderCanceledMessageData.cs
@@ -2,59 +2,58 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class OrderCanceledMessageData
 {
-    public class OrderCanceledMessageData
+    [JsonConstructor]
+    public OrderCanceledMessageData(
+        OrderEventType eventType,
+        string symbol,
+        long orderId,
+        OrderType type,
+        string clientOrderId,
+        string orderSource,
+        decimal orderPrice,
+        decimal orderSize,
+        decimal orderValue,
+        OrderStatus orderStatus,
+        string remainingAmount,
+        string accumulativeAmount,
+        DateTimeOffset lastActivityTime)
     {
-        [JsonConstructor]
-        public OrderCanceledMessageData(
-            OrderEventType eventType,
-            string symbol,
-            long orderId,
-            OrderType type,
-            string clientOrderId,
-            string orderSource,
-            decimal orderPrice,
-            decimal orderSize,
-            decimal orderValue,
-            OrderStatus orderStatus,
-            string remainingAmount,
-            string accumulativeAmount,
-            DateTimeOffset lastActivityTime)
-        {
-            EventType = eventType;
-            Symbol = symbol;
-            OrderId = orderId;
-            Type = type;
-            ClientOrderId = clientOrderId;
-            OrderSource = orderSource;
-            OrderPrice = orderPrice;
-            OrderSize = orderSize;
-            OrderValue = orderValue;
-            OrderStatus = orderStatus;
-            RemainingAmount = remainingAmount;
-            AccumulativeAmount = accumulativeAmount;
-            LastActivityTime = lastActivityTime;
-        }
-
-        public OrderEventType EventType { get; }
-        public string Symbol { get; }
-        public long OrderId { get; }
-        public OrderType Type { get; }
-        public string ClientOrderId { get; }
-        public string OrderSource { get; }
-        public decimal OrderPrice { get; }
-        public decimal OrderSize { get; }
-        public decimal OrderValue { get; }
-        public OrderStatus OrderStatus { get; }
-
-        [JsonProperty("remainAmt")]
-        public string RemainingAmount { get; }
-
-        [JsonProperty("execAmt")]
-        public string AccumulativeAmount { get; }
-
-        [JsonProperty("lastActTime")]
-        public DateTimeOffset LastActivityTime { get; }
+        EventType = eventType;
+        Symbol = symbol;
+        OrderId = orderId;
+        Type = type;
+        ClientOrderId = clientOrderId;
+        OrderSource = orderSource;
+        OrderPrice = orderPrice;
+        OrderSize = orderSize;
+        OrderValue = orderValue;
+        OrderStatus = orderStatus;
+        RemainingAmount = remainingAmount;
+        AccumulativeAmount = accumulativeAmount;
+        LastActivityTime = lastActivityTime;
     }
+
+    public OrderEventType EventType { get; }
+    public string Symbol { get; }
+    public long OrderId { get; }
+    public OrderType Type { get; }
+    public string ClientOrderId { get; }
+    public string OrderSource { get; }
+    public decimal OrderPrice { get; }
+    public decimal OrderSize { get; }
+    public decimal OrderValue { get; }
+    public OrderStatus OrderStatus { get; }
+
+    [JsonProperty("remainAmt")]
+    public string RemainingAmount { get; }
+
+    [JsonProperty("execAmt")]
+    public string AccumulativeAmount { get; }
+
+    [JsonProperty("lastActTime")]
+    public DateTimeOffset LastActivityTime { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderSubmittedMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderSubmittedMessage.cs
@@ -2,33 +2,32 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class OrderSubmittedMessage : AccountResponseBase<OrderSubmittedMessageData>
 {
-    public class OrderSubmittedMessage : AccountResponseBase<OrderSubmittedMessageData>
+    public OrderSubmittedMessage(
+        string action,
+        string channel,
+        OrderSubmittedMessageData data)
+        : base(action, channel, data)
     {
-        public OrderSubmittedMessage(
-            string action,
-            string channel,
-            OrderSubmittedMessageData data)
-            : base(action, channel, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out OrderSubmittedMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    AccountSubscriptionType.Orders.ToTopicId(),
-                    OrderEventType.Creation.ToString().ToLower()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out OrderSubmittedMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                AccountSubscriptionType.Orders.ToTopicId(),
+                OrderEventType.Creation.ToString().ToLower()
+            },
+            out response);
 
-            return result && response?.Data?.OrderId > 0;
-        }
+        return result && response?.Data?.OrderId > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderSubmittedMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderSubmittedMessageData.cs
@@ -2,50 +2,49 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
-{
-    public class OrderSubmittedMessageData
-    {
-        [JsonConstructor]
-        public OrderSubmittedMessageData(
-            OrderEventType eventType,
-            string symbol,
-            long accountId,
-            long orderId,
-            string clientOrderId,
-            string orderSource,
-            decimal orderPrice,
-            decimal orderSize,
-            decimal orderValue,
-            OrderType type,
-            OrderStatus orderStatus,
-            DateTimeOffset orderCreateTime)
-        {
-            EventType = eventType;
-            Symbol = symbol;
-            AccountId = accountId;
-            OrderId = orderId;
-            ClientOrderId = clientOrderId;
-            OrderSource = orderSource;
-            OrderPrice = orderPrice;
-            OrderSize = orderSize;
-            OrderValue = orderValue;
-            Type = type;
-            OrderStatus = orderStatus;
-            OrderCreateTime = orderCreateTime;
-        }
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
 
-        public OrderEventType EventType { get; }
-        public string Symbol { get; }
-        public long AccountId { get; }
-        public long OrderId { get; }
-        public string ClientOrderId { get; }
-        public string OrderSource { get; }
-        public decimal OrderPrice { get; }
-        public decimal OrderSize { get; }
-        public decimal OrderValue { get; }
-        public OrderType Type { get; }
-        public OrderStatus OrderStatus { get; }
-        public DateTimeOffset OrderCreateTime { get; }
+public class OrderSubmittedMessageData
+{
+    [JsonConstructor]
+    public OrderSubmittedMessageData(
+        OrderEventType eventType,
+        string symbol,
+        long accountId,
+        long orderId,
+        string clientOrderId,
+        string orderSource,
+        decimal orderPrice,
+        decimal orderSize,
+        decimal orderValue,
+        OrderType type,
+        OrderStatus orderStatus,
+        DateTimeOffset orderCreateTime)
+    {
+        EventType = eventType;
+        Symbol = symbol;
+        AccountId = accountId;
+        OrderId = orderId;
+        ClientOrderId = clientOrderId;
+        OrderSource = orderSource;
+        OrderPrice = orderPrice;
+        OrderSize = orderSize;
+        OrderValue = orderValue;
+        Type = type;
+        OrderStatus = orderStatus;
+        OrderCreateTime = orderCreateTime;
     }
+
+    public OrderEventType EventType { get; }
+    public string Symbol { get; }
+    public long AccountId { get; }
+    public long OrderId { get; }
+    public string ClientOrderId { get; }
+    public string OrderSource { get; }
+    public decimal OrderPrice { get; }
+    public decimal OrderSize { get; }
+    public decimal OrderValue { get; }
+    public OrderType Type { get; }
+    public OrderStatus OrderStatus { get; }
+    public DateTimeOffset OrderCreateTime { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderTradedMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderTradedMessage.cs
@@ -2,30 +2,29 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class OrderTradedMessage : AccountResponseBase<OrderTradedMessageData>
 {
-    public class OrderTradedMessage : AccountResponseBase<OrderTradedMessageData>
+    public OrderTradedMessage(string action, string channel, OrderTradedMessageData data)
+        : base(action, channel, data)
     {
-        public OrderTradedMessage(string action, string channel, OrderTradedMessageData data)
-            : base(action, channel, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out OrderTradedMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    AccountSubscriptionType.Orders.ToTopicId(),
-                    OrderEventType.Trade.ToString().ToLower()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out OrderTradedMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                AccountSubscriptionType.Orders.ToTopicId(),
+                OrderEventType.Trade.ToString().ToLower()
+            },
+            out response);
 
-            return result && response?.Data?.OrderId > 0;
-        }
+        return result && response?.Data?.OrderId > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderTradedMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderTradedMessageData.cs
@@ -2,69 +2,68 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class OrderTradedMessageData
 {
-    public class OrderTradedMessageData
+    [JsonConstructor]
+    public OrderTradedMessageData(
+        OrderEventType eventType,
+        string symbol,
+        decimal tradePrice,
+        decimal tradeVolume,
+        long orderId,
+        OrderType type,
+        string clientOrderId,
+        string orderSource,
+        decimal orderPrice,
+        decimal orderSize,
+        decimal orderValue,
+        long tradeId,
+        DateTimeOffset tradeTime,
+        bool aggressor,
+        OrderStatus orderStatus,
+        decimal remainingAmount,
+        decimal accumulativeAmount)
     {
-        [JsonConstructor]
-        public OrderTradedMessageData(
-            OrderEventType eventType,
-            string symbol,
-            decimal tradePrice,
-            decimal tradeVolume,
-            long orderId,
-            OrderType type,
-            string clientOrderId,
-            string orderSource,
-            decimal orderPrice,
-            decimal orderSize,
-            decimal orderValue,
-            long tradeId,
-            DateTimeOffset tradeTime,
-            bool aggressor,
-            OrderStatus orderStatus,
-            decimal remainingAmount,
-            decimal accumulativeAmount)
-        {
-            EventType = eventType;
-            Symbol = symbol;
-            TradePrice = tradePrice;
-            TradeVolume = tradeVolume;
-            OrderId = orderId;
-            Type = type;
-            ClientOrderId = clientOrderId;
-            OrderSource = orderSource;
-            OrderPrice = orderPrice;
-            OrderSize = orderSize;
-            OrderValue = orderValue;
-            TradeId = tradeId;
-            TradeTime = tradeTime;
-            Aggressor = aggressor;
-            OrderStatus = orderStatus;
-            RemainingAmount = remainingAmount;
-            AccumulativeAmount = accumulativeAmount;
-        }
-
-        public OrderEventType EventType { get; }
-        public string Symbol { get; }
-        public decimal TradePrice { get; }
-        public decimal TradeVolume { get; }
-        public long OrderId { get; }
-        public OrderType Type { get; }
-        public string ClientOrderId { get; }
-        public string OrderSource { get; }
-        public decimal OrderPrice { get; }
-        public decimal OrderSize { get; }
-        public decimal OrderValue { get; }
-        public long TradeId { get; }
-        public DateTimeOffset TradeTime { get; }
-        public bool Aggressor { get; }
-        public OrderStatus OrderStatus { get; }
-
-        [JsonProperty("remainAmt")]
-        public decimal RemainingAmount { get; }
-
-        [JsonProperty("execAmt")]
-        public decimal AccumulativeAmount { get; }
+        EventType = eventType;
+        Symbol = symbol;
+        TradePrice = tradePrice;
+        TradeVolume = tradeVolume;
+        OrderId = orderId;
+        Type = type;
+        ClientOrderId = clientOrderId;
+        OrderSource = orderSource;
+        OrderPrice = orderPrice;
+        OrderSize = orderSize;
+        OrderValue = orderValue;
+        TradeId = tradeId;
+        TradeTime = tradeTime;
+        Aggressor = aggressor;
+        OrderStatus = orderStatus;
+        RemainingAmount = remainingAmount;
+        AccumulativeAmount = accumulativeAmount;
     }
+
+    public OrderEventType EventType { get; }
+    public string Symbol { get; }
+    public decimal TradePrice { get; }
+    public decimal TradeVolume { get; }
+    public long OrderId { get; }
+    public OrderType Type { get; }
+    public string ClientOrderId { get; }
+    public string OrderSource { get; }
+    public decimal OrderPrice { get; }
+    public decimal OrderSize { get; }
+    public decimal OrderValue { get; }
+    public long TradeId { get; }
+    public DateTimeOffset TradeTime { get; }
+    public bool Aggressor { get; }
+    public OrderStatus OrderStatus { get; }
+
+    [JsonProperty("remainAmt")]
+    public decimal RemainingAmount { get; }
+
+    [JsonProperty("execAmt")]
+    public decimal AccumulativeAmount { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderUpdatesSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/OrderUpdates/OrderUpdatesSubscribeRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.Account.Values;
 
-namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates
+namespace Huobi.Client.Websocket.Messages.Account.OrderUpdates;
+
+public class OrderUpdatesSubscribeRequest : AccountSubscribeRequest
 {
-    public class OrderUpdatesSubscribeRequest : AccountSubscribeRequest
+    public OrderUpdatesSubscribeRequest(string symbol)
+        : base(symbol, AccountSubscriptionType.Orders)
     {
-        public OrderUpdatesSubscribeRequest(string symbol)
-            : base(symbol, AccountSubscriptionType.Orders)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/TradeDetails/TradeDetailsMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/TradeDetails/TradeDetailsMessage.cs
@@ -3,34 +3,33 @@ using Huobi.Client.Websocket.Messages.Account.Values;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.TradeDetails
+namespace Huobi.Client.Websocket.Messages.Account.TradeDetails;
+
+public class TradeDetailsMessage
 {
-    public class TradeDetailsMessage
+    [JsonConstructor]
+    public TradeDetailsMessage(string? channel, TradeDetailsMessageData? data)
     {
-        [JsonConstructor]
-        public TradeDetailsMessage(string? channel, TradeDetailsMessageData? data)
-        {
-            Channel = channel ?? string.Empty;
-            Data = data;
-        }
+        Channel = channel ?? string.Empty;
+        Data = data;
+    }
 
-        [JsonProperty("ch")]
-        public string Channel { get; }
+    [JsonProperty("ch")]
+    public string Channel { get; }
 
-        public TradeDetailsMessageData? Data { get; }
+    public TradeDetailsMessageData? Data { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out TradeDetailsMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                AccountSubscriptionType.TradeDetails.ToTopicId(),
-                "\"message\"",
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out TradeDetailsMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            AccountSubscriptionType.TradeDetails.ToTopicId(),
+            "\"message\"",
+            out response);
 
-            return result && response?.Data?.TradeTime.Ticks > 0;
-        }
+        return result && response?.Data?.TradeTime.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/TradeDetails/TradeDetailsMessageData.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/TradeDetails/TradeDetailsMessageData.cs
@@ -2,89 +2,88 @@
 using Huobi.Client.Websocket.Messages.Account.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.Account.TradeDetails
+namespace Huobi.Client.Websocket.Messages.Account.TradeDetails;
+
+public class TradeDetailsMessageData
 {
-    public class TradeDetailsMessageData
+    [JsonConstructor]
+    public TradeDetailsMessageData(
+        TradeEventType eventType,
+        string symbol,
+        long orderId,
+        decimal tradePrice,
+        decimal tradeVolume,
+        OrderSide orderSide,
+        OrderType orderType,
+        bool aggressor,
+        long tradeId,
+        DateTimeOffset tradeTime,
+        decimal transactionFee,
+        string feeCurrency,
+        decimal feeDeduct,
+        string feeDeductType,
+        long accountId,
+        string source,
+        decimal orderPrice,
+        decimal orderSize,
+        decimal orderValue,
+        string clientOrderId,
+        decimal stopPrice,
+        string @operator,
+        DateTimeOffset orderCreateTime,
+        OrderStatus orderStatus)
     {
-        [JsonConstructor]
-        public TradeDetailsMessageData(
-            TradeEventType eventType,
-            string symbol,
-            long orderId,
-            decimal tradePrice,
-            decimal tradeVolume,
-            OrderSide orderSide,
-            OrderType orderType,
-            bool aggressor,
-            long tradeId,
-            DateTimeOffset tradeTime,
-            decimal transactionFee,
-            string feeCurrency,
-            decimal feeDeduct,
-            string feeDeductType,
-            long accountId,
-            string source,
-            decimal orderPrice,
-            decimal orderSize,
-            decimal orderValue,
-            string clientOrderId,
-            decimal stopPrice,
-            string @operator,
-            DateTimeOffset orderCreateTime,
-            OrderStatus orderStatus)
-        {
-            EventType = eventType;
-            Symbol = symbol;
-            OrderId = orderId;
-            TradePrice = tradePrice;
-            TradeVolume = tradeVolume;
-            OrderSide = orderSide;
-            OrderType = orderType;
-            Aggressor = aggressor;
-            TradeId = tradeId;
-            TradeTime = tradeTime;
-            TransactionFee = transactionFee;
-            FeeCurrency = feeCurrency;
-            FeeDeduct = feeDeduct;
-            FeeDeductType = feeDeductType;
-            AccountId = accountId;
-            Source = source;
-            OrderPrice = orderPrice;
-            OrderSize = orderSize;
-            OrderValue = orderValue;
-            ClientOrderId = clientOrderId;
-            StopPrice = stopPrice;
-            Operator = @operator;
-            OrderCreateTime = orderCreateTime;
-            OrderStatus = orderStatus;
-        }
-
-        public TradeEventType EventType { get; }
-        public string Symbol { get; }
-        public long OrderId { get; }
-        public decimal TradePrice { get; }
-        public decimal TradeVolume { get; }
-        public OrderSide OrderSide { get; }
-        public OrderType OrderType { get; }
-        public bool Aggressor { get; }
-        public long TradeId { get; }
-        public DateTimeOffset TradeTime { get; }
-
-        [JsonProperty("transactFee")]
-        public decimal TransactionFee { get; }
-
-        public string FeeCurrency { get; }
-        public decimal FeeDeduct { get; }
-        public string FeeDeductType { get; }
-        public long AccountId { get; }
-        public string Source { get; }
-        public decimal OrderPrice { get; }
-        public decimal OrderSize { get; }
-        public decimal OrderValue { get; }
-        public string ClientOrderId { get; }
-        public decimal StopPrice { get; }
-        public string Operator { get; }
-        public DateTimeOffset OrderCreateTime { get; }
-        public OrderStatus OrderStatus { get; }
+        EventType = eventType;
+        Symbol = symbol;
+        OrderId = orderId;
+        TradePrice = tradePrice;
+        TradeVolume = tradeVolume;
+        OrderSide = orderSide;
+        OrderType = orderType;
+        Aggressor = aggressor;
+        TradeId = tradeId;
+        TradeTime = tradeTime;
+        TransactionFee = transactionFee;
+        FeeCurrency = feeCurrency;
+        FeeDeduct = feeDeduct;
+        FeeDeductType = feeDeductType;
+        AccountId = accountId;
+        Source = source;
+        OrderPrice = orderPrice;
+        OrderSize = orderSize;
+        OrderValue = orderValue;
+        ClientOrderId = clientOrderId;
+        StopPrice = stopPrice;
+        Operator = @operator;
+        OrderCreateTime = orderCreateTime;
+        OrderStatus = orderStatus;
     }
+
+    public TradeEventType EventType { get; }
+    public string Symbol { get; }
+    public long OrderId { get; }
+    public decimal TradePrice { get; }
+    public decimal TradeVolume { get; }
+    public OrderSide OrderSide { get; }
+    public OrderType OrderType { get; }
+    public bool Aggressor { get; }
+    public long TradeId { get; }
+    public DateTimeOffset TradeTime { get; }
+
+    [JsonProperty("transactFee")]
+    public decimal TransactionFee { get; }
+
+    public string FeeCurrency { get; }
+    public decimal FeeDeduct { get; }
+    public string FeeDeductType { get; }
+    public long AccountId { get; }
+    public string Source { get; }
+    public decimal OrderPrice { get; }
+    public decimal OrderSize { get; }
+    public decimal OrderValue { get; }
+    public string ClientOrderId { get; }
+    public decimal StopPrice { get; }
+    public string Operator { get; }
+    public DateTimeOffset OrderCreateTime { get; }
+    public OrderStatus OrderStatus { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/TradeDetails/TradeDetailsSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/TradeDetails/TradeDetailsSubscribeRequest.cs
@@ -1,17 +1,16 @@
 ﻿using Huobi.Client.Websocket.Messages.Account.Values;
 
-namespace Huobi.Client.Websocket.Messages.Account.TradeDetails
-{
-    public class TradeDetailsSubscribeRequest : AccountSubscribeRequest
-    {
-        public TradeDetailsSubscribeRequest(string symbol, bool withCancellationEvents = false)
-            : base(FormatSymbol(symbol, withCancellationEvents), AccountSubscriptionType.TradeDetails)
-        {
-        }
+namespace Huobi.Client.Websocket.Messages.Account.TradeDetails;
 
-        private static string FormatSymbol(string symbol, bool withCancellationEvents)
-        {
-            return $"{symbol}#{(withCancellationEvents ? "1" : "0")}";
-        }
+public class TradeDetailsSubscribeRequest : AccountSubscribeRequest
+{
+    public TradeDetailsSubscribeRequest(string symbol, bool withCancellationEvents = false)
+        : base(FormatSymbol(symbol, withCancellationEvents), AccountSubscriptionType.TradeDetails)
+    {
+    }
+
+    private static string FormatSymbol(string symbol, bool withCancellationEvents)
+    {
+        return $"{symbol}#{(withCancellationEvents ? "1" : "0")}";
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/AccountChangeType.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/AccountChangeType.cs
@@ -1,19 +1,18 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum AccountChangeType
 {
-    public enum AccountChangeType
-    {
-        Unknown,
-        OrderPlace,
-        OrderMatch,
-        OrderRefund,
-        OrderCancel,
-        OrderFeeRefund,
-        MarginTransfer,
-        MarginLoan,
-        MarginInterest,
-        MarginRepay,
-        Deposit,
-        Withdraw,
-        Other
-    }
+    Unknown,
+    OrderPlace,
+    OrderMatch,
+    OrderRefund,
+    OrderCancel,
+    OrderFeeRefund,
+    MarginTransfer,
+    MarginLoan,
+    MarginInterest,
+    MarginRepay,
+    Deposit,
+    Withdraw,
+    Other
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/AccountSubscriptionType.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/AccountSubscriptionType.cs
@@ -1,9 +1,8 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum AccountSubscriptionType
 {
-    public enum AccountSubscriptionType
-    {
-        AccountUpdates,
-        Orders,
-        TradeDetails
-    }
+    AccountUpdates,
+    Orders,
+    TradeDetails
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/AccountSubscriptionTypeExtensions.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/AccountSubscriptionTypeExtensions.cs
@@ -1,21 +1,20 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Messages.Account.Values
+namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public static class AccountSubscriptionTypeExtensions
 {
-    public static class AccountSubscriptionTypeExtensions
+    public static string ToTopicId(this AccountSubscriptionType subscriptionType)
     {
-        public static string ToTopicId(this AccountSubscriptionType subscriptionType)
+        return subscriptionType switch
         {
-            return subscriptionType switch
-            {
-                AccountSubscriptionType.Orders => "orders",
-                AccountSubscriptionType.TradeDetails => "trade.clearing",
-                AccountSubscriptionType.AccountUpdates => "accounts.update",
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(subscriptionType),
-                    subscriptionType,
-                    $"Unable to translate {nameof(subscriptionType)} value '{subscriptionType}' to topic ID!")
-            };
-        }
+            AccountSubscriptionType.Orders => "orders",
+            AccountSubscriptionType.TradeDetails => "trade.clearing",
+            AccountSubscriptionType.AccountUpdates => "accounts.update",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(subscriptionType),
+                subscriptionType,
+                $"Unable to translate {nameof(subscriptionType)} value '{subscriptionType}' to topic ID!")
+        };
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/AccountType.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/AccountType.cs
@@ -1,10 +1,9 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum AccountType
 {
-    public enum AccountType
-    {
-        Unknown,
-        Trade,
-        Loan,
-        Interest
-    }
+    Unknown,
+    Trade,
+    Loan,
+    Interest
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/OrderEventType.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/OrderEventType.cs
@@ -1,12 +1,11 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum OrderEventType
 {
-    public enum OrderEventType
-    {
-        Unknown,
-        Trigger,
-        Deletion,
-        Creation,
-        Trade,
-        Cancellation
-    }
+    Unknown,
+    Trigger,
+    Deletion,
+    Creation,
+    Trade,
+    Cancellation
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/OrderSide.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/OrderSide.cs
@@ -1,9 +1,8 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum OrderSide
 {
-    public enum OrderSide
-    {
-        Unknown,
-        Buy,
-        Sell
-    }
+    Unknown,
+    Buy,
+    Sell
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/OrderStatus.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/OrderStatus.cs
@@ -1,13 +1,12 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum OrderStatus
 {
-    public enum OrderStatus
-    {
-        Unknown,
-        Rejected,
-        PartialCanceled,
-        Canceled,
-        Submitted,
-        PartialFilled,
-        Filled
-    }
+    Unknown,
+    Rejected,
+    PartialCanceled,
+    Canceled,
+    Submitted,
+    PartialFilled,
+    Filled
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/OrderType.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/OrderType.cs
@@ -1,21 +1,20 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum OrderType
 {
-    public enum OrderType
-    {
-        Unknown,
-        BuyMarket,
-        SellMarket,
-        BuyLimit,
-        SellLimit,
-        BuyLimitMaker,
-        SellLimitMaker,
-        BuyIoc,
-        SellIoc,
-        BuyLimitFok,
-        SellLimitFok,
-        BuyStopLimit,
-        SellStopLimit,
-        BuyStopLimitFok,
-        SellStopLimitFok
-    }
+    Unknown,
+    BuyMarket,
+    SellMarket,
+    BuyLimit,
+    SellLimit,
+    BuyLimitMaker,
+    SellLimitMaker,
+    BuyIoc,
+    SellIoc,
+    BuyLimitFok,
+    SellLimitFok,
+    BuyStopLimit,
+    SellStopLimit,
+    BuyStopLimitFok,
+    SellStopLimitFok
 }

--- a/src/Huobi.Client.Websocket/Messages/Account/Values/TradeEventType.cs
+++ b/src/Huobi.Client.Websocket/Messages/Account/Values/TradeEventType.cs
@@ -1,9 +1,8 @@
-﻿namespace Huobi.Client.Websocket.Messages.Account.Values
+﻿namespace Huobi.Client.Websocket.Messages.Account.Values;
+
+public enum TradeEventType
 {
-    public enum TradeEventType
-    {
-        Unknown,
-        Trade,
-        Cancellation
-    }
+    Unknown,
+    Trade,
+    Cancellation
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/ErrorMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/ErrorMessage.cs
@@ -3,38 +3,37 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class ErrorMessage
 {
-    public class ErrorMessage
+    [JsonConstructor]
+    public ErrorMessage(string? status, string? errorCode, string? message, DateTimeOffset timestamp, string? reqId)
     {
-        [JsonConstructor]
-        public ErrorMessage(string? status, string? errorCode, string? message, DateTimeOffset timestamp, string? reqId)
-        {
-            Status = status ?? string.Empty;
-            ErrorCode = errorCode ?? string.Empty;
-            Message = message ?? string.Empty;
-            Timestamp = timestamp;
-            ReqId = reqId;
-        }
+        Status = status ?? string.Empty;
+        ErrorCode = errorCode ?? string.Empty;
+        Message = message ?? string.Empty;
+        Timestamp = timestamp;
+        ReqId = reqId;
+    }
 
-        public string Status { get; }
+    public string Status { get; }
 
-        [JsonProperty("err-code")]
-        public string ErrorCode { get; }
+    [JsonProperty("err-code")]
+    public string ErrorCode { get; }
 
-        [JsonProperty("err-msg")]
-        public string Message { get; }
+    [JsonProperty("err-msg")]
+    public string Message { get; }
 
-        [JsonProperty("id")]
-        public string? ReqId { get; }
+    [JsonProperty("id")]
+    public string? ReqId { get; }
 
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
 
-        internal static bool TryParse(IHuobiSerializer serializer, string input, [MaybeNullWhen(false)] out ErrorMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(input, "\"err-code\"", out response);
-            return result && !string.IsNullOrEmpty(response?.ErrorCode);
-        }
+    internal static bool TryParse(IHuobiSerializer serializer, string input, [MaybeNullWhen(false)] out ErrorMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(input, "\"err-code\"", out response);
+        return result && !string.IsNullOrEmpty(response?.ErrorCode);
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/IResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/IResponse.cs
@@ -1,7 +1,6 @@
-﻿namespace Huobi.Client.Websocket.Messages.MarketData
+﻿namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public interface IResponse
 {
-    public interface IResponse
-    {
-        string Topic { get; }
-    }
+    string Topic { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferSubscribeRequest.cs
@@ -1,14 +1,13 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer;
+
+public class MarketBestBidOfferSubscribeRequest : SubscribeRequest
 {
-    public class MarketBestBidOfferSubscribeRequest : SubscribeRequest
+    public MarketBestBidOfferSubscribeRequest(
+        string reqId,
+        string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketBestBidOffer)
     {
-        public MarketBestBidOfferSubscribeRequest(
-            string reqId,
-            string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketBestBidOffer)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferTick.cs
@@ -1,34 +1,33 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer;
+
+public class MarketBestBidOfferTick
 {
-    public class MarketBestBidOfferTick
+    [JsonConstructor]
+    public MarketBestBidOfferTick(
+        string symbol,
+        DateTimeOffset quoteTime,
+        decimal bid,
+        decimal bidSize,
+        decimal ask,
+        decimal askSize,
+        long seqId)
     {
-        [JsonConstructor]
-        public MarketBestBidOfferTick(
-            string symbol,
-            DateTimeOffset quoteTime,
-            decimal bid,
-            decimal bidSize,
-            decimal ask,
-            decimal askSize,
-            long seqId)
-        {
-            Symbol = symbol;
-            QuoteTime = quoteTime;
-            Bid = bid;
-            BidSize = bidSize;
-            Ask = ask;
-            AskSize = askSize;
-            SeqId = seqId;
-        }
-        public string Symbol { get; }
-        public DateTimeOffset QuoteTime { get; }
-        public decimal Bid { get; }
-        public decimal BidSize { get; }
-        public decimal Ask { get; }
-        public decimal AskSize { get; }
-        public long SeqId { get; }
+        Symbol = symbol;
+        QuoteTime = quoteTime;
+        Bid = bid;
+        BidSize = bidSize;
+        Ask = ask;
+        AskSize = askSize;
+        SeqId = seqId;
     }
+    public string Symbol { get; }
+    public DateTimeOffset QuoteTime { get; }
+    public decimal Bid { get; }
+    public decimal BidSize { get; }
+    public decimal Ask { get; }
+    public decimal AskSize { get; }
+    public long SeqId { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferUnsubscribeRequest.cs
@@ -1,14 +1,13 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer;
+
+public class MarketBestBidOfferUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketBestBidOfferUnsubscribeRequest : UnsubscribeRequest
+    public MarketBestBidOfferUnsubscribeRequest(
+        string reqId,
+        string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketBestBidOffer)
     {
-        public MarketBestBidOfferUnsubscribeRequest(
-            string reqId,
-            string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketBestBidOffer)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketBestBidOffer/MarketBestBidOfferUpdateMessage.cs
@@ -3,30 +3,29 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketBestBidOffer;
+
+public class MarketBestBidOfferUpdateMessage : UpdateMessage<MarketBestBidOfferTick>
 {
-    public class MarketBestBidOfferUpdateMessage : UpdateMessage<MarketBestBidOfferTick>
+    public MarketBestBidOfferUpdateMessage(string topic, DateTimeOffset timestamp, MarketBestBidOfferTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketBestBidOfferUpdateMessage(string topic, DateTimeOffset timestamp, MarketBestBidOfferTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketBestBidOfferUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketBestBidOffer.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketBestBidOfferUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketBestBidOffer.ToTopicId()
+            },
+            out response);
 
-            return result && !string.IsNullOrEmpty(response?.Tick?.Symbol);
-        }
+        return result && !string.IsNullOrEmpty(response?.Tick?.Symbol);
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPricePullRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPricePullRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPricePullRequest : PullRequest
 {
-    public class MarketByPricePullRequest : PullRequest
+    public MarketByPricePullRequest(
+        string reqId,
+        string symbol,
+        int levels)
+        : base(reqId, symbol, SubscriptionType.MarketByPrice, levels.ToString())
     {
-        public MarketByPricePullRequest(
-            string reqId,
-            string symbol,
-            int levels)
-            : base(reqId, symbol, SubscriptionType.MarketByPrice, levels.ToString())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPricePullResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPricePullResponse.cs
@@ -4,36 +4,35 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPricePullResponse : PullResponse<MarketByPricePullTick>
 {
-    public class MarketByPricePullResponse : PullResponse<MarketByPricePullTick>
+    [JsonConstructor]
+    public MarketByPricePullResponse(
+        string reqId,
+        string status,
+        string topic,
+        DateTimeOffset timestamp,
+        MarketByPricePullTick data)
+        : base(reqId, status, topic, timestamp, data)
     {
-        [JsonConstructor]
-        public MarketByPricePullResponse(
-            string reqId,
-            string status,
-            string topic,
-            DateTimeOffset timestamp,
-            MarketByPricePullTick data)
-            : base(reqId, status, topic, timestamp, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketByPricePullResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"rep\"",
-                    SubscriptionType.MarketByPrice.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketByPricePullResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"rep\"",
+                SubscriptionType.MarketByPrice.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Data?.SeqNum > 0;
-        }
+        return result && response?.Data?.SeqNum > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPricePullTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPricePullTick.cs
@@ -3,24 +3,23 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer.Converters;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPricePullTick
 {
-    public class MarketByPricePullTick
+    [JsonConstructor]
+    public MarketByPricePullTick(long seqNum, BookLevel[]? bids, BookLevel[]? asks)
     {
-        [JsonConstructor]
-        public MarketByPricePullTick(long seqNum, BookLevel[]? bids, BookLevel[]? asks)
-        {
-            SeqNum = seqNum;
-            Bids = bids ?? Array.Empty<BookLevel>();
-            Asks = asks ?? Array.Empty<BookLevel>();
-        }
-
-        public long SeqNum { get; }
-
-        [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Bid)]
-        public BookLevel[] Bids { get; }
-
-        [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Ask)]
-        public BookLevel[] Asks { get; }
+        SeqNum = seqNum;
+        Bids = bids ?? Array.Empty<BookLevel>();
+        Asks = asks ?? Array.Empty<BookLevel>();
     }
+
+    public long SeqNum { get; }
+
+    [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Bid)]
+    public BookLevel[] Bids { get; }
+
+    [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Ask)]
+    public BookLevel[] Asks { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceRefreshSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceRefreshSubscribeRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceRefreshSubscribeRequest : SubscribeRequest
 {
-    public class MarketByPriceRefreshSubscribeRequest : SubscribeRequest
+    public MarketByPriceRefreshSubscribeRequest(
+        string reqId,
+        string symbol,
+        int levels)
+        : base(reqId, symbol, SubscriptionType.MarketByPriceRefresh, levels.ToString())
     {
-        public MarketByPriceRefreshSubscribeRequest(
-            string reqId,
-            string symbol,
-            int levels)
-            : base(reqId, symbol, SubscriptionType.MarketByPriceRefresh, levels.ToString())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceRefreshUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceRefreshUnsubscribeRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceRefreshUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketByPriceRefreshUnsubscribeRequest : UnsubscribeRequest
+    public MarketByPriceRefreshUnsubscribeRequest(
+        string reqId,
+        string symbol,
+        int levels)
+        : base(reqId, symbol, SubscriptionType.MarketByPriceRefresh, levels.ToString())
     {
-        public MarketByPriceRefreshUnsubscribeRequest(
-            string reqId,
-            string symbol,
-            int levels)
-            : base(reqId, symbol, SubscriptionType.MarketByPriceRefresh, levels.ToString())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceRefreshUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceRefreshUpdateMessage.cs
@@ -3,30 +3,29 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceRefreshUpdateMessage : UpdateMessage<MarketByPriceTick>
 {
-    public class MarketByPriceRefreshUpdateMessage : UpdateMessage<MarketByPriceTick>
+    public MarketByPriceRefreshUpdateMessage(string topic, DateTimeOffset timestamp, MarketByPriceTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketByPriceRefreshUpdateMessage(string topic, DateTimeOffset timestamp, MarketByPriceTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketByPriceRefreshUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketByPriceRefresh.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketByPriceRefreshUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketByPriceRefresh.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Tick?.SeqNum > 0;
-        }
+        return result && response?.Tick?.SeqNum > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceSubscribeRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceSubscribeRequest : SubscribeRequest
 {
-    public class MarketByPriceSubscribeRequest : SubscribeRequest
+    public MarketByPriceSubscribeRequest(
+        string reqId,
+        string symbol,
+        int levels)
+        : base(reqId, symbol, SubscriptionType.MarketByPrice, levels.ToString())
     {
-        public MarketByPriceSubscribeRequest(
-            string reqId,
-            string symbol,
-            int levels)
-            : base(reqId, symbol, SubscriptionType.MarketByPrice, levels.ToString())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceTick.cs
@@ -2,26 +2,25 @@
 using Huobi.Client.Websocket.Serializer.Converters;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceTick
 {
-    public class MarketByPriceTick
+    [JsonConstructor]
+    public MarketByPriceTick(long seqNum, long prevSeqNum, BookLevel[]? bids, BookLevel[]? asks)
     {
-        [JsonConstructor]
-        public MarketByPriceTick(long seqNum, long prevSeqNum, BookLevel[]? bids, BookLevel[]? asks)
-        {
-            SeqNum = seqNum;
-            PrevSeqNum = prevSeqNum;
-            Bids = bids;
-            Asks = asks;
-        }
-
-        public long SeqNum { get; }
-        public long PrevSeqNum { get; }
-
-        [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Bid)]
-        public BookLevel[]? Bids { get; }
-
-        [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Ask)]
-        public BookLevel[]? Asks { get; }
+        SeqNum = seqNum;
+        PrevSeqNum = prevSeqNum;
+        Bids = bids;
+        Asks = asks;
     }
+
+    public long SeqNum { get; }
+    public long PrevSeqNum { get; }
+
+    [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Bid)]
+    public BookLevel[]? Bids { get; }
+
+    [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Ask)]
+    public BookLevel[]? Asks { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceUnsubscribeRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketByPriceUnsubscribeRequest : UnsubscribeRequest
+    public MarketByPriceUnsubscribeRequest(
+        string reqId,
+        string symbol,
+        int levels)
+        : base(reqId, symbol, SubscriptionType.MarketByPrice, levels.ToString())
     {
-        public MarketByPriceUnsubscribeRequest(
-            string reqId,
-            string symbol,
-            int levels)
-            : base(reqId, symbol, SubscriptionType.MarketByPrice, levels.ToString())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketByPrice/MarketByPriceUpdateMessage.cs
@@ -3,34 +3,33 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketByPrice;
+
+public class MarketByPriceUpdateMessage : UpdateMessage<MarketByPriceTick>
 {
-    public class MarketByPriceUpdateMessage : UpdateMessage<MarketByPriceTick>
+    public MarketByPriceUpdateMessage(string topic, DateTimeOffset timestamp, MarketByPriceTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketByPriceUpdateMessage(string topic, DateTimeOffset timestamp, MarketByPriceTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketByPriceUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketByPrice.ToTopicId()
-                },
-                new[]
-                {
-                    SubscriptionType.MarketByPriceRefresh.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketByPriceUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketByPrice.ToTopicId()
+            },
+            new[]
+            {
+                SubscriptionType.MarketByPriceRefresh.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Tick?.SeqNum > 0;
-        }
+        return result && response?.Tick?.SeqNum > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickPullRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickPullRequest.cs
@@ -2,40 +2,39 @@
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick;
+
+public class MarketCandlestickPullRequest : PullRequest
 {
-    public class MarketCandlestickPullRequest : PullRequest
+    public MarketCandlestickPullRequest(
+        string reqId,
+        string symbol,
+        MarketCandlestickPeriodType periodType)
+        : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
     {
-        public MarketCandlestickPullRequest(
-            string reqId,
-            string symbol,
-            MarketCandlestickPeriodType periodType)
-            : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
-        {
-        }
-
-        public MarketCandlestickPullRequest(
-            string reqId,
-            string symbol,
-            MarketCandlestickPeriodType periodType,
-            DateTimeOffset from,
-            DateTimeOffset to)
-            : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
-        {
-            From = from;
-            To = to;
-        }
-
-        [JsonIgnore]
-        public DateTimeOffset? From { get; }
-
-        [JsonIgnore]
-        public DateTimeOffset? To { get; }
-
-        [JsonProperty("from")]
-        public long? FromTick => From?.ToUnixTimeSeconds();
-
-        [JsonProperty("to")]
-        public long? ToTick => To?.ToUnixTimeSeconds();
     }
+
+    public MarketCandlestickPullRequest(
+        string reqId,
+        string symbol,
+        MarketCandlestickPeriodType periodType,
+        DateTimeOffset from,
+        DateTimeOffset to)
+        : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
+    {
+        From = from;
+        To = to;
+    }
+
+    [JsonIgnore]
+    public DateTimeOffset? From { get; }
+
+    [JsonIgnore]
+    public DateTimeOffset? To { get; }
+
+    [JsonProperty("from")]
+    public long? FromTick => From?.ToUnixTimeSeconds();
+
+    [JsonProperty("to")]
+    public long? ToTick => To?.ToUnixTimeSeconds();
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickPullResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickPullResponse.cs
@@ -5,36 +5,35 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick;
+
+public class MarketCandlestickPullResponse : PullResponse<MarketCandlestickTick[]>
 {
-    public class MarketCandlestickPullResponse : PullResponse<MarketCandlestickTick[]>
+    [JsonConstructor]
+    public MarketCandlestickPullResponse(
+        string reqId,
+        string status,
+        string topic,
+        DateTimeOffset timestamp,
+        MarketCandlestickTick[] data)
+        : base(reqId, status, topic, timestamp, data)
     {
-        [JsonConstructor]
-        public MarketCandlestickPullResponse(
-            string reqId,
-            string status,
-            string topic,
-            DateTimeOffset timestamp,
-            MarketCandlestickTick[] data)
-            : base(reqId, status, topic, timestamp, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketCandlestickPullResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"rep\"",
-                    SubscriptionType.MarketCandlestick.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketCandlestickPullResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"rep\"",
+                SubscriptionType.MarketCandlestick.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Data?.FirstOrDefault()?.Id > 0;
-        }
+        return result && response?.Data?.FirstOrDefault()?.Id > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickSubscribeRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick;
+
+public class MarketCandlestickSubscribeRequest : SubscribeRequest
 {
-    public class MarketCandlestickSubscribeRequest : SubscribeRequest
+    public MarketCandlestickSubscribeRequest(
+        string reqId,
+        string symbol,
+        MarketCandlestickPeriodType periodType)
+        : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
     {
-        public MarketCandlestickSubscribeRequest(
-            string reqId,
-            string symbol,
-            MarketCandlestickPeriodType periodType)
-            : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickTick.cs
@@ -1,37 +1,36 @@
 ﻿using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick
-{
-    public class MarketCandlestickTick
-    {
-        [JsonConstructor]
-        public MarketCandlestickTick(
-            long id,
-            decimal amount,
-            int count,
-            decimal open,
-            decimal close,
-            decimal low,
-            decimal high,
-            decimal vol)
-        {
-            Id = id;
-            Amount = amount;
-            Count = count;
-            Open = open;
-            Close = close;
-            Low = low;
-            High = high;
-            Vol = vol;
-        }
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick;
 
-        public long Id { get; }
-        public decimal Amount { get; }
-        public int Count { get; }
-        public decimal Open { get; }
-        public decimal Close { get; }
-        public decimal Low { get; }
-        public decimal High { get; }
-        public decimal Vol { get; }
+public class MarketCandlestickTick
+{
+    [JsonConstructor]
+    public MarketCandlestickTick(
+        long id,
+        decimal amount,
+        int count,
+        decimal open,
+        decimal close,
+        decimal low,
+        decimal high,
+        decimal vol)
+    {
+        Id = id;
+        Amount = amount;
+        Count = count;
+        Open = open;
+        Close = close;
+        Low = low;
+        High = high;
+        Vol = vol;
     }
+
+    public long Id { get; }
+    public decimal Amount { get; }
+    public int Count { get; }
+    public decimal Open { get; }
+    public decimal Close { get; }
+    public decimal Low { get; }
+    public decimal High { get; }
+    public decimal Vol { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickUnsubscribeRequest.cs
@@ -1,15 +1,14 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick;
+
+public class MarketCandlestickUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketCandlestickUnsubscribeRequest : UnsubscribeRequest
+    public MarketCandlestickUnsubscribeRequest(
+        string reqId,
+        string symbol,
+        MarketCandlestickPeriodType periodType)
+        : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
     {
-        public MarketCandlestickUnsubscribeRequest(
-            string reqId,
-            string symbol,
-            MarketCandlestickPeriodType periodType)
-            : base(reqId, symbol, SubscriptionType.MarketCandlestick, periodType.ToStep())
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketCandlestick/MarketCandlestickUpdateMessage.cs
@@ -3,30 +3,29 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketCandlestick;
+
+public class MarketCandlestickUpdateMessage : UpdateMessage<MarketCandlestickTick>
 {
-    public class MarketCandlestickUpdateMessage : UpdateMessage<MarketCandlestickTick>
+    public MarketCandlestickUpdateMessage(string topic, DateTimeOffset timestamp, MarketCandlestickTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketCandlestickUpdateMessage(string topic, DateTimeOffset timestamp, MarketCandlestickTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketCandlestickUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketCandlestick.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketCandlestickUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketCandlestick.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Tick?.Id > 0;
-        }
+        return result && response?.Tick?.Id > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthPullRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthPullRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
+
+public class MarketDepthPullRequest : PullRequest
 {
-    public class MarketDepthPullRequest : PullRequest
+    public MarketDepthPullRequest(string reqId, string symbol, int stepIndex)
+        : base(reqId, symbol, SubscriptionType.MarketDepth, $"step{stepIndex}")
     {
-        public MarketDepthPullRequest(string reqId, string symbol, int stepIndex)
-            : base(reqId, symbol, SubscriptionType.MarketDepth, $"step{stepIndex}")
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthPullResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthPullResponse.cs
@@ -4,36 +4,35 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
+
+public class MarketDepthPullResponse : PullResponse<MarketDepthTick>
 {
-    public class MarketDepthPullResponse : PullResponse<MarketDepthTick>
+    [JsonConstructor]
+    public MarketDepthPullResponse(
+        string reqId,
+        string status,
+        string topic,
+        DateTimeOffset timestamp,
+        MarketDepthTick data)
+        : base(reqId, status, topic, timestamp, data)
     {
-        [JsonConstructor]
-        public MarketDepthPullResponse(
-            string reqId,
-            string status,
-            string topic,
-            DateTimeOffset timestamp,
-            MarketDepthTick data)
-            : base(reqId, status, topic, timestamp, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketDepthPullResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"rep\"",
-                    SubscriptionType.MarketDepth.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketDepthPullResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"rep\"",
+                SubscriptionType.MarketDepth.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Data?.Timestamp.Ticks > 0;
-        }
+        return result && response?.Data?.Timestamp.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthSubscribeRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
+
+public class MarketDepthSubscribeRequest : SubscribeRequest
 {
-    public class MarketDepthSubscribeRequest : SubscribeRequest
+    public MarketDepthSubscribeRequest(string reqId, string symbol, int stepIndex)
+        : base(reqId, symbol, SubscriptionType.MarketDepth, $"step{stepIndex}")
     {
-        public MarketDepthSubscribeRequest(string reqId, string symbol, int stepIndex)
-            : base(reqId, symbol, SubscriptionType.MarketDepth, $"step{stepIndex}")
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthTick.cs
@@ -3,28 +3,27 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer.Converters;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
+
+public class MarketDepthTick
 {
-    public class MarketDepthTick
+    [JsonConstructor]
+    public MarketDepthTick(BookLevel[]? bids, BookLevel[]? asks, long version, DateTimeOffset timestamp)
     {
-        [JsonConstructor]
-        public MarketDepthTick(BookLevel[]? bids, BookLevel[]? asks, long version, DateTimeOffset timestamp)
-        {
-            Bids = bids ?? Array.Empty<BookLevel>();
-            Asks = asks ?? Array.Empty<BookLevel>();
-            Version = version;
-            Timestamp = timestamp;
-        }
-
-        [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Bid)]
-        public BookLevel[] Bids { get; }
-
-        [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Ask)]
-        public BookLevel[] Asks { get; }
-
-        public long Version { get; }
-
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
+        Bids = bids ?? Array.Empty<BookLevel>();
+        Asks = asks ?? Array.Empty<BookLevel>();
+        Version = version;
+        Timestamp = timestamp;
     }
+
+    [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Bid)]
+    public BookLevel[] Bids { get; }
+
+    [JsonConverter(typeof(OrderBookLevelConverter), OrderBookSide.Ask)]
+    public BookLevel[] Asks { get; }
+
+    public long Version { get; }
+
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthUnsubscribeRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
+
+public class MarketDepthUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketDepthUnsubscribeRequest : UnsubscribeRequest
+    public MarketDepthUnsubscribeRequest(string reqId, string symbol, int stepIndex)
+        : base(reqId, symbol, SubscriptionType.MarketDepth, $"step{stepIndex}")
     {
-        public MarketDepthUnsubscribeRequest(string reqId, string symbol, int stepIndex)
-            : base(reqId, symbol, SubscriptionType.MarketDepth, $"step{stepIndex}")
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDepth/MarketDepthUpdateMessage.cs
@@ -3,30 +3,29 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDepth;
+
+public class MarketDepthUpdateMessage : UpdateMessage<MarketDepthTick>
 {
-    public class MarketDepthUpdateMessage : UpdateMessage<MarketDepthTick>
+    public MarketDepthUpdateMessage(string topic, DateTimeOffset timestamp, MarketDepthTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketDepthUpdateMessage(string topic, DateTimeOffset timestamp, MarketDepthTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketDepthUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketDepth.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketDepthUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketDepth.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Tick?.Timestamp.Ticks > 0;
-        }
+        return result && response?.Tick?.Timestamp.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketCandlestickPullRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketCandlestickPullRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
+
+public class MarketDetailsPullRequest : PullRequest
 {
-    public class MarketDetailsPullRequest : PullRequest
+    public MarketDetailsPullRequest(string reqId, string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketDetails)
     {
-        public MarketDetailsPullRequest(string reqId, string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketDetails)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketCandlestickPullResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketCandlestickPullResponse.cs
@@ -4,40 +4,39 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
+
+public class MarketDetailsPullResponse : PullResponse<MarketDetailsTick>
 {
-    public class MarketDetailsPullResponse : PullResponse<MarketDetailsTick>
+    [JsonConstructor]
+    public MarketDetailsPullResponse(
+        string reqId,
+        string status,
+        string topic,
+        DateTimeOffset timestamp,
+        MarketDetailsTick data)
+        : base(reqId, status, topic, timestamp, data)
     {
-        [JsonConstructor]
-        public MarketDetailsPullResponse(
-            string reqId,
-            string status,
-            string topic,
-            DateTimeOffset timestamp,
-            MarketDetailsTick data)
-            : base(reqId, status, topic, timestamp, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketDetailsPullResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"rep\"",
-                    SubscriptionType.MarketDetails.ToTopicId()
-                },
-                new[]
-                {
-                    SubscriptionType.MarketTradeDetail.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketDetailsPullResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"rep\"",
+                SubscriptionType.MarketDetails.ToTopicId()
+            },
+            new[]
+            {
+                SubscriptionType.MarketTradeDetail.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Data?.Id > 0;
-        }
+        return result && response?.Data?.Id > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsSubscribeRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
+
+public class MarketDetailsSubscribeRequest : SubscribeRequest
 {
-    public class MarketDetailsSubscribeRequest : SubscribeRequest
+    public MarketDetailsSubscribeRequest(string reqId, string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketDetails)
     {
-        public MarketDetailsSubscribeRequest(string reqId, string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketDetails)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsTick.cs
@@ -1,37 +1,36 @@
 ﻿using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails
-{
-    public class MarketDetailsTick
-    {
-        [JsonConstructor]
-        public MarketDetailsTick(
-            long id,
-            decimal amount,
-            int count,
-            decimal open,
-            decimal close,
-            decimal low,
-            decimal high,
-            decimal vol)
-        {
-            Id = id;
-            Amount = amount;
-            Count = count;
-            Open = open;
-            Close = close;
-            Low = low;
-            High = high;
-            Vol = vol;
-        }
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
 
-        public long Id { get; }
-        public decimal Amount { get; }
-        public int Count { get; }
-        public decimal Open { get; }
-        public decimal Close { get; }
-        public decimal Low { get; }
-        public decimal High { get; }
-        public decimal Vol { get; }
+public class MarketDetailsTick
+{
+    [JsonConstructor]
+    public MarketDetailsTick(
+        long id,
+        decimal amount,
+        int count,
+        decimal open,
+        decimal close,
+        decimal low,
+        decimal high,
+        decimal vol)
+    {
+        Id = id;
+        Amount = amount;
+        Count = count;
+        Open = open;
+        Close = close;
+        Low = low;
+        High = high;
+        Vol = vol;
     }
+
+    public long Id { get; }
+    public decimal Amount { get; }
+    public int Count { get; }
+    public decimal Open { get; }
+    public decimal Close { get; }
+    public decimal Low { get; }
+    public decimal High { get; }
+    public decimal Vol { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsUnsubscribeRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
+
+public class MarketDetailsUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketDetailsUnsubscribeRequest : UnsubscribeRequest
+    public MarketDetailsUnsubscribeRequest(string reqId, string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketDetails)
     {
-        public MarketDetailsUnsubscribeRequest(string reqId, string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketDetails)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketDetails/MarketDetailsUpdateMessage.cs
@@ -3,34 +3,33 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketDetails;
+
+public class MarketDetailsUpdateMessage : UpdateMessage<MarketDetailsTick>
 {
-    public class MarketDetailsUpdateMessage : UpdateMessage<MarketDetailsTick>
+    public MarketDetailsUpdateMessage(string topic, DateTimeOffset timestamp, MarketDetailsTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketDetailsUpdateMessage(string topic, DateTimeOffset timestamp, MarketDetailsTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketDetailsUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketDetails.ToTopicId()
-                },
-                new[]
-                {
-                    SubscriptionType.MarketTradeDetail.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketDetailsUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketDetails.ToTopicId()
+            },
+            new[]
+            {
+                SubscriptionType.MarketTradeDetail.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Tick?.Id > 0;
-        }
+        return result && response?.Tick?.Id > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailPullRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailPullRequest.cs
@@ -1,12 +1,11 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailPullRequest : PullRequest
 {
-    public class MarketTradeDetailPullRequest : PullRequest
+    public MarketTradeDetailPullRequest(string reqId, string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketTradeDetail)
     {
-        public MarketTradeDetailPullRequest(string reqId, string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketTradeDetail)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailPullResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailPullResponse.cs
@@ -5,36 +5,35 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailPullResponse : PullResponse<MarketTradeDetailTickDataItem[]>
 {
-    public class MarketTradeDetailPullResponse : PullResponse<MarketTradeDetailTickDataItem[]>
+    [JsonConstructor]
+    public MarketTradeDetailPullResponse(
+        string reqId,
+        string status,
+        string topic,
+        DateTimeOffset timestamp,
+        MarketTradeDetailTickDataItem[] data)
+        : base(reqId, status, topic, timestamp, data)
     {
-        [JsonConstructor]
-        public MarketTradeDetailPullResponse(
-            string reqId,
-            string status,
-            string topic,
-            DateTimeOffset timestamp,
-            MarketTradeDetailTickDataItem[] data)
-            : base(reqId, status, topic, timestamp, data)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketTradeDetailPullResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"rep\"",
-                    SubscriptionType.MarketTradeDetail.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketTradeDetailPullResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"rep\"",
+                SubscriptionType.MarketTradeDetail.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Data?.FirstOrDefault()?.Timestamp.Ticks > 0;
-        }
+        return result && response?.Data?.FirstOrDefault()?.Timestamp.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailSubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailSubscribeRequest.cs
@@ -1,14 +1,13 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailSubscribeRequest : SubscribeRequest
 {
-    public class MarketTradeDetailSubscribeRequest : SubscribeRequest
+    public MarketTradeDetailSubscribeRequest(
+        string reqId,
+        string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketTradeDetail)
     {
-        public MarketTradeDetailSubscribeRequest(
-            string reqId,
-            string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketTradeDetail)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailTick.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailTick.cs
@@ -1,23 +1,22 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailTick
 {
-    public class MarketTradeDetailTick
+    [JsonConstructor]
+    public MarketTradeDetailTick(long id, DateTimeOffset timestamp, MarketTradeDetailTickDataItem[]? data)
     {
-        [JsonConstructor]
-        public MarketTradeDetailTick(long id, DateTimeOffset timestamp, MarketTradeDetailTickDataItem[]? data)
-        {
-            Id = id;
-            Timestamp = timestamp;
-            Data = data ?? Array.Empty<MarketTradeDetailTickDataItem>();
-        }
-
-        public long Id { get; }
-
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
-        
-        public MarketTradeDetailTickDataItem[] Data { get; }
+        Id = id;
+        Timestamp = timestamp;
+        Data = data ?? Array.Empty<MarketTradeDetailTickDataItem>();
     }
+
+    public long Id { get; }
+
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
+        
+    public MarketTradeDetailTickDataItem[] Data { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailTickDataItem.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailTickDataItem.cs
@@ -2,35 +2,34 @@
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailTickDataItem
 {
-    public class MarketTradeDetailTickDataItem
+    [JsonConstructor]
+    public MarketTradeDetailTickDataItem(
+        string id,
+        decimal amount,
+        long tradeId,
+        decimal price,
+        DateTimeOffset timestamp,
+        TradeSide direction)
     {
-        [JsonConstructor]
-        public MarketTradeDetailTickDataItem(
-            string id,
-            decimal amount,
-            long tradeId,
-            decimal price,
-            DateTimeOffset timestamp,
-            TradeSide direction)
-        {
-            Id = id;
-            Amount = amount;
-            TradeId = tradeId;
-            Price = price;
-            Timestamp = timestamp;
-            Direction = direction;
-        }
-
-        public string Id { get; }
-        public decimal Amount { get; }
-        public long TradeId { get; }
-        public decimal Price { get; }
-
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
-
-        public TradeSide Direction { get; }
+        Id = id;
+        Amount = amount;
+        TradeId = tradeId;
+        Price = price;
+        Timestamp = timestamp;
+        Direction = direction;
     }
+
+    public string Id { get; }
+    public decimal Amount { get; }
+    public long TradeId { get; }
+    public decimal Price { get; }
+
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
+
+    public TradeSide Direction { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailUnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailUnsubscribeRequest.cs
@@ -1,14 +1,13 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailUnsubscribeRequest : UnsubscribeRequest
 {
-    public class MarketTradeDetailUnsubscribeRequest : UnsubscribeRequest
+    public MarketTradeDetailUnsubscribeRequest(
+        string reqId,
+        string symbol)
+        : base(reqId, symbol, SubscriptionType.MarketTradeDetail)
     {
-        public MarketTradeDetailUnsubscribeRequest(
-            string reqId,
-            string symbol)
-            : base(reqId, symbol, SubscriptionType.MarketTradeDetail)
-        {
-        }
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailUpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/MarketTradeDetail/MarketTradeDetailUpdateMessage.cs
@@ -3,30 +3,29 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Huobi.Client.Websocket.Serializer;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail
+namespace Huobi.Client.Websocket.Messages.MarketData.MarketTradeDetail;
+
+public class MarketTradeDetailUpdateMessage : UpdateMessage<MarketTradeDetailTick>
 {
-    public class MarketTradeDetailUpdateMessage : UpdateMessage<MarketTradeDetailTick>
+    public MarketTradeDetailUpdateMessage(string topic, DateTimeOffset timestamp, MarketTradeDetailTick tick)
+        : base(topic, timestamp, tick)
     {
-        public MarketTradeDetailUpdateMessage(string topic, DateTimeOffset timestamp, MarketTradeDetailTick tick)
-            : base(topic, timestamp, tick)
-        {
-        }
+    }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out MarketTradeDetailUpdateMessage response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"tick\"",
-                    SubscriptionType.MarketTradeDetail.ToTopicId()
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out MarketTradeDetailUpdateMessage response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"tick\"",
+                SubscriptionType.MarketTradeDetail.ToTopicId()
+            },
+            out response);
 
-            return result && response?.Tick?.Timestamp.Ticks > 0;
-        }
+        return result && response?.Tick?.Timestamp.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/PingRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/PingRequest.cs
@@ -2,33 +2,32 @@
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class PingRequest
 {
-    public class PingRequest
+    [JsonConstructor]
+    public PingRequest(long value)
     {
-        [JsonConstructor]
-        public PingRequest(long value)
-        {
-            Value = value;
-        }
+        Value = value;
+    }
 
-        [JsonProperty("ping")]
-        public long Value { get; }
+    [JsonProperty("ping")]
+    public long Value { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out PingRequest response)
-        {
-            var result = serializer.TryDeserializeIfContains(
-                input,
-                new[]
-                {
-                    "\"ping\""
-                },
-                out response);
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out PingRequest response)
+    {
+        var result = serializer.TryDeserializeIfContains(
+            input,
+            new[]
+            {
+                "\"ping\""
+            },
+            out response);
 
-            return result && response?.Value > 0;
-        }
+        return result && response?.Value > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/PongResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/PongResponse.cs
@@ -1,16 +1,15 @@
 ﻿using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
-{
-    public class PongResponse
-    {
-        [JsonConstructor]
-        public PongResponse(long value)
-        {
-            Value = value;
-        }
+namespace Huobi.Client.Websocket.Messages.MarketData;
 
-        [JsonProperty("pong")]
-        public long Value { get; }
+public class PongResponse
+{
+    [JsonConstructor]
+    public PongResponse(long value)
+    {
+        Value = value;
     }
+
+    [JsonProperty("pong")]
+    public long Value { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/PullRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/PullRequest.cs
@@ -2,24 +2,23 @@
 using Huobi.Client.Websocket.Utils;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
-{
-    public class PullRequest : RequestBase
-    {
-        public PullRequest(string reqId, string symbol, SubscriptionType subscriptionType, string? step = null)
-            : base(reqId)
-        {
-            Validations.ValidateInput(symbol, nameof(symbol));
-            
-            if (!string.IsNullOrEmpty(step))
-            {
-                step = $".{step}";
-            }
+namespace Huobi.Client.Websocket.Messages.MarketData;
 
-            Topic = $"{HuobiConstants.MARKET_PREFIX}.{symbol}.{subscriptionType.ToTopicId()}{step}";
+public class PullRequest : RequestBase
+{
+    public PullRequest(string reqId, string symbol, SubscriptionType subscriptionType, string? step = null)
+        : base(reqId)
+    {
+        Validations.ValidateInput(symbol, nameof(symbol));
+            
+        if (!string.IsNullOrEmpty(step))
+        {
+            step = $".{step}";
         }
 
-        [JsonProperty("req")]
-        public string Topic { get; }
+        Topic = $"{HuobiConstants.MARKET_PREFIX}.{symbol}.{subscriptionType.ToTopicId()}{step}";
     }
+
+    [JsonProperty("req")]
+    public string Topic { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/PullResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/PullResponse.cs
@@ -1,31 +1,30 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class PullResponse<TTick> : IResponse
+    where TTick : class
 {
-    public class PullResponse<TTick> : IResponse
-        where TTick : class
+    public PullResponse(string? reqId, string? status, string? topic, DateTimeOffset timestamp, TTick? data)
     {
-        public PullResponse(string? reqId, string? status, string? topic, DateTimeOffset timestamp, TTick? data)
-        {
-            ReqId = reqId ?? string.Empty;
-            Status = status ?? string.Empty;
-            Topic = topic ?? string.Empty;
-            Timestamp = timestamp;
-            Data = data;
-        }
-
-        [JsonProperty("id")]
-        public string ReqId { get; }
-
-        public string Status { get; }
-
-        [JsonProperty("rep")]
-        public string Topic { get; }
-
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
-
-        public TTick? Data { get; }
+        ReqId = reqId ?? string.Empty;
+        Status = status ?? string.Empty;
+        Topic = topic ?? string.Empty;
+        Timestamp = timestamp;
+        Data = data;
     }
+
+    [JsonProperty("id")]
+    public string ReqId { get; }
+
+    public string Status { get; }
+
+    [JsonProperty("rep")]
+    public string Topic { get; }
+
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
+
+    public TTick? Data { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/RequestBase.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/RequestBase.cs
@@ -1,18 +1,17 @@
 ﻿using Huobi.Client.Websocket.Utils;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public abstract class RequestBase
 {
-    public abstract class RequestBase
+    protected RequestBase(string reqId)
     {
-        protected RequestBase(string reqId)
-        {
-            Validations.ValidateInput(reqId, nameof(reqId));
+        Validations.ValidateInput(reqId, nameof(reqId));
 
-            ReqId = reqId;
-        }
-
-        [JsonProperty("id")]
-        public string ReqId { get; }
+        ReqId = reqId;
     }
+
+    [JsonProperty("id")]
+    public string ReqId { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/ResponseExtensions.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/ResponseExtensions.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public static class ResponseExtensions
 {
-    public static class ResponseExtensions
+    public static string ParseSymbolFromTopic(this IResponse response)
     {
-        public static string ParseSymbolFromTopic(this IResponse response)
+        // faster then use of regex or split
+
+        var prefixLength = HuobiConstants.MARKET_PREFIX.Length + 1;
+        if (response.Topic.Length > prefixLength)
         {
-            // faster then use of regex or split
-
-            var prefixLength = HuobiConstants.MARKET_PREFIX.Length + 1;
-            if (response.Topic.Length > prefixLength)
+            var withoutPrefix = response.Topic.Substring(prefixLength);
+            var length = withoutPrefix.IndexOf(".", StringComparison.Ordinal);
+            if (length > 0)
             {
-                var withoutPrefix = response.Topic.Substring(prefixLength);
-                var length = withoutPrefix.IndexOf(".", StringComparison.Ordinal);
-                if (length > 0)
-                {
-                    return withoutPrefix.Substring(0, length);
-                }
+                return withoutPrefix.Substring(0, length);
             }
-
-            throw new HuobiWebsocketClientException("Unable to parse symbol from topic: " + response.Topic);
         }
+
+        throw new HuobiWebsocketClientException("Unable to parse symbol from topic: " + response.Topic);
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/SubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/SubscribeRequest.cs
@@ -1,22 +1,21 @@
 ﻿using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
-{
-    public class SubscribeRequest : RequestBase
-    {
-        public SubscribeRequest(string reqId, string symbol, SubscriptionType subscriptionType, string? step = null)
-            : base(reqId)
-        {
-            if (!string.IsNullOrEmpty(step))
-            {
-                step = $".{step}";
-            }
+namespace Huobi.Client.Websocket.Messages.MarketData;
 
-            Topic = $"{HuobiConstants.MARKET_PREFIX}.{symbol}.{subscriptionType.ToTopicId()}{step}";
+public class SubscribeRequest : RequestBase
+{
+    public SubscribeRequest(string reqId, string symbol, SubscriptionType subscriptionType, string? step = null)
+        : base(reqId)
+    {
+        if (!string.IsNullOrEmpty(step))
+        {
+            step = $".{step}";
         }
 
-        [JsonProperty("sub")]
-        public string Topic { get; }
+        Topic = $"{HuobiConstants.MARKET_PREFIX}.{symbol}.{subscriptionType.ToTopicId()}{step}";
     }
+
+    [JsonProperty("sub")]
+    public string Topic { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/SubscribeResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/SubscribeResponse.cs
@@ -3,37 +3,36 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class SubscribeResponse
 {
-    public class SubscribeResponse
+    [JsonConstructor]
+    public SubscribeResponse(string? reqId, string? status, string? topic, DateTimeOffset timestamp)
     {
-        [JsonConstructor]
-        public SubscribeResponse(string? reqId, string? status, string? topic, DateTimeOffset timestamp)
-        {
-            ReqId = reqId ?? string.Empty;
-            Status = status ?? string.Empty;
-            Topic = topic ?? string.Empty;
-            Timestamp = timestamp;
-        }
+        ReqId = reqId ?? string.Empty;
+        Status = status ?? string.Empty;
+        Topic = topic ?? string.Empty;
+        Timestamp = timestamp;
+    }
 
-        [JsonProperty("id")]
-        public string ReqId { get; }
+    [JsonProperty("id")]
+    public string ReqId { get; }
 
-        public string Status { get; }
+    public string Status { get; }
 
-        [JsonProperty("subbed")]
-        public string Topic { get; }
+    [JsonProperty("subbed")]
+    public string Topic { get; }
 
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out SubscribeResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(input, "\"subbed\"", out response);
-            return result && response?.Timestamp.Ticks > 0;
-        }
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out SubscribeResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(input, "\"subbed\"", out response);
+        return result && response?.Timestamp.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/UnsubscribeRequest.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/UnsubscribeRequest.cs
@@ -2,24 +2,23 @@
 using Huobi.Client.Websocket.Utils;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class UnsubscribeRequest : RequestBase
 {
-    public class UnsubscribeRequest : RequestBase
+    public UnsubscribeRequest(string reqId, string symbol, SubscriptionType subscriptionType, string? step = null)
+        : base(reqId)
     {
-        public UnsubscribeRequest(string reqId, string symbol, SubscriptionType subscriptionType, string? step = null)
-            : base(reqId)
+        Validations.ValidateInput(symbol, nameof(symbol));
+
+        if (!string.IsNullOrEmpty(step))
         {
-            Validations.ValidateInput(symbol, nameof(symbol));
-
-            if (!string.IsNullOrEmpty(step))
-            {
-                step = $".{step}";
-            }
-
-            Topic = $"{HuobiConstants.MARKET_PREFIX}.{symbol}.{subscriptionType.ToTopicId()}{step}";
+            step = $".{step}";
         }
 
-        [JsonProperty("unsub")]
-        public string Topic { get; }
+        Topic = $"{HuobiConstants.MARKET_PREFIX}.{symbol}.{subscriptionType.ToTopicId()}{step}";
     }
+
+    [JsonProperty("unsub")]
+    public string Topic { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/UnsubscribeResponse.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/UnsubscribeResponse.cs
@@ -3,37 +3,36 @@ using System.Diagnostics.CodeAnalysis;
 using Huobi.Client.Websocket.Serializer;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class UnsubscribeResponse : IResponse
 {
-    public class UnsubscribeResponse : IResponse
+    [JsonConstructor]
+    public UnsubscribeResponse(string? reqId, string? status, string? topic, DateTimeOffset timestamp)
     {
-        [JsonConstructor]
-        public UnsubscribeResponse(string? reqId, string? status, string? topic, DateTimeOffset timestamp)
-        {
-            ReqId = reqId ?? string.Empty;
-            Status = status ?? string.Empty;
-            Topic = topic ?? string.Empty;
-            Timestamp = timestamp;
-        }
+        ReqId = reqId ?? string.Empty;
+        Status = status ?? string.Empty;
+        Topic = topic ?? string.Empty;
+        Timestamp = timestamp;
+    }
         
-        [JsonProperty("id")]
-        public string ReqId { get; }
+    [JsonProperty("id")]
+    public string ReqId { get; }
 
-        public string Status { get; }
+    public string Status { get; }
 
-        [JsonProperty("unsubbed")]
-        public string Topic { get; }
+    [JsonProperty("unsubbed")]
+    public string Topic { get; }
 
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
 
-        internal static bool TryParse(
-            IHuobiSerializer serializer,
-            string input,
-            [MaybeNullWhen(false)] out UnsubscribeResponse response)
-        {
-            var result = serializer.TryDeserializeIfContains(input, "\"unsubbed\"", out response);
-            return result && response?.Timestamp.Ticks > 0;
-        }
+    internal static bool TryParse(
+        IHuobiSerializer serializer,
+        string input,
+        [MaybeNullWhen(false)] out UnsubscribeResponse response)
+    {
+        var result = serializer.TryDeserializeIfContains(input, "\"unsubbed\"", out response);
+        return result && response?.Timestamp.Ticks > 0;
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/UpdateMessage.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/UpdateMessage.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Messages.MarketData
+namespace Huobi.Client.Websocket.Messages.MarketData;
+
+public class UpdateMessage<TTick> : IResponse
+    where TTick : class
 {
-    public class UpdateMessage<TTick> : IResponse
-        where TTick : class
+    [JsonConstructor]
+    public UpdateMessage(string? topic, DateTimeOffset timestamp, TTick? tick)
     {
-        [JsonConstructor]
-        public UpdateMessage(string? topic, DateTimeOffset timestamp, TTick? tick)
-        {
-            Topic = topic ?? string.Empty;
-            Timestamp = timestamp;
-            Tick = tick;
-        }
-
-        [JsonProperty("ch")]
-        public string Topic { get; }
-
-        [JsonProperty("ts")]
-        public DateTimeOffset Timestamp { get; }
-
-        public TTick? Tick { get; }
+        Topic = topic ?? string.Empty;
+        Timestamp = timestamp;
+        Tick = tick;
     }
+
+    [JsonProperty("ch")]
+    public string Topic { get; }
+
+    [JsonProperty("ts")]
+    public DateTimeOffset Timestamp { get; }
+
+    public TTick? Tick { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/BookLevel.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/BookLevel.cs
@@ -1,18 +1,17 @@
-﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values
+﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public class BookLevel
 {
-    public class BookLevel
+    public BookLevel(OrderBookSide side, decimal price, decimal size)
     {
-        public BookLevel(OrderBookSide side, decimal price, decimal size)
-        {
-            Side = side;
-            Price = price;
-            Size = size;
-        }
-
-        public OrderBookSide Side { get; }
-
-        public decimal Price { get; }
-
-        public decimal Size { get; }
+        Side = side;
+        Price = price;
+        Size = size;
     }
+
+    public OrderBookSide Side { get; }
+
+    public decimal Price { get; }
+
+    public decimal Size { get; }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/MarketCandlestickPeriodType.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/MarketCandlestickPeriodType.cs
@@ -1,16 +1,15 @@
-﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values
+﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public enum MarketCandlestickPeriodType
 {
-    public enum MarketCandlestickPeriodType
-    {
-        OneMinute,
-        FiveMinutes,
-        FifteenMinutes,
-        ThirtyMinutes,
-        SixtyMinutes,
-        FourHours,
-        OneDay,
-        OneWeek,
-        OneMonth,
-        OneYear
-    }
+    OneMinute,
+    FiveMinutes,
+    FifteenMinutes,
+    ThirtyMinutes,
+    SixtyMinutes,
+    FourHours,
+    OneDay,
+    OneWeek,
+    OneMonth,
+    OneYear
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/MarketCandlestickPeriodTypeExtensions.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/MarketCandlestickPeriodTypeExtensions.cs
@@ -1,28 +1,27 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.Values
+namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public static class MarketCandlestickPeriodTypeExtensions
 {
-    public static class MarketCandlestickPeriodTypeExtensions
+    public static string ToStep(this MarketCandlestickPeriodType periodType)
     {
-        public static string ToStep(this MarketCandlestickPeriodType periodType)
+        return periodType switch
         {
-            return periodType switch
-            {
-                MarketCandlestickPeriodType.OneMinute => "1min",
-                MarketCandlestickPeriodType.FiveMinutes => "5min",
-                MarketCandlestickPeriodType.FifteenMinutes => "15min",
-                MarketCandlestickPeriodType.ThirtyMinutes => "30min",
-                MarketCandlestickPeriodType.SixtyMinutes => "60min",
-                MarketCandlestickPeriodType.FourHours => "4hour",
-                MarketCandlestickPeriodType.OneDay => "1day",
-                MarketCandlestickPeriodType.OneWeek => "1week",
-                MarketCandlestickPeriodType.OneMonth => "1mon",
-                MarketCandlestickPeriodType.OneYear => "1year",
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(periodType),
-                    periodType,
-                    $"Unable to translate {periodType} to API step!")
-            };
-        }
+            MarketCandlestickPeriodType.OneMinute => "1min",
+            MarketCandlestickPeriodType.FiveMinutes => "5min",
+            MarketCandlestickPeriodType.FifteenMinutes => "15min",
+            MarketCandlestickPeriodType.ThirtyMinutes => "30min",
+            MarketCandlestickPeriodType.SixtyMinutes => "60min",
+            MarketCandlestickPeriodType.FourHours => "4hour",
+            MarketCandlestickPeriodType.OneDay => "1day",
+            MarketCandlestickPeriodType.OneWeek => "1week",
+            MarketCandlestickPeriodType.OneMonth => "1mon",
+            MarketCandlestickPeriodType.OneYear => "1year",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(periodType),
+                periodType,
+                $"Unable to translate {periodType} to API step!")
+        };
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/OrderBookSide.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/OrderBookSide.cs
@@ -1,8 +1,7 @@
-﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values
+﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public enum OrderBookSide
 {
-    public enum OrderBookSide
-    {
-        Bid,
-        Ask
-    }
+    Bid,
+    Ask
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/SubscriptionType.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/SubscriptionType.cs
@@ -1,13 +1,12 @@
-﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values
+﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public enum SubscriptionType
 {
-    public enum SubscriptionType
-    {
-        MarketCandlestick,
-        MarketDepth,
-        MarketByPrice,
-        MarketByPriceRefresh,
-        MarketBestBidOffer,
-        MarketTradeDetail,
-        MarketDetails
-    }
+    MarketCandlestick,
+    MarketDepth,
+    MarketByPrice,
+    MarketByPriceRefresh,
+    MarketBestBidOffer,
+    MarketTradeDetail,
+    MarketDetails
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/SubscriptionTypeExtensions.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/SubscriptionTypeExtensions.cs
@@ -1,25 +1,24 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Messages.MarketData.Values
+namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public static class SubscriptionTypeExtensions
 {
-    public static class SubscriptionTypeExtensions
+    public static string ToTopicId(this SubscriptionType subscriptionType)
     {
-        public static string ToTopicId(this SubscriptionType subscriptionType)
+        return subscriptionType switch
         {
-            return subscriptionType switch
-            {
-                SubscriptionType.MarketCandlestick => "kline",
-                SubscriptionType.MarketDepth => "depth",
-                SubscriptionType.MarketByPrice => "mbp",
-                SubscriptionType.MarketByPriceRefresh => "mbp.refresh",
-                SubscriptionType.MarketBestBidOffer => "bbo",
-                SubscriptionType.MarketTradeDetail => "trade.detail",
-                SubscriptionType.MarketDetails => "detail",
-                _ => throw new ArgumentOutOfRangeException(
-                    nameof(subscriptionType),
-                    subscriptionType,
-                    $"Unable to translate {nameof(subscriptionType)} value '{subscriptionType}' to topic ID!")
-            };
-        }
+            SubscriptionType.MarketCandlestick => "kline",
+            SubscriptionType.MarketDepth => "depth",
+            SubscriptionType.MarketByPrice => "mbp",
+            SubscriptionType.MarketByPriceRefresh => "mbp.refresh",
+            SubscriptionType.MarketBestBidOffer => "bbo",
+            SubscriptionType.MarketTradeDetail => "trade.detail",
+            SubscriptionType.MarketDetails => "detail",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(subscriptionType),
+                subscriptionType,
+                $"Unable to translate {nameof(subscriptionType)} value '{subscriptionType}' to topic ID!")
+        };
     }
 }

--- a/src/Huobi.Client.Websocket/Messages/MarketData/Values/TradeSide.cs
+++ b/src/Huobi.Client.Websocket/Messages/MarketData/Values/TradeSide.cs
@@ -1,8 +1,7 @@
-﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values
+﻿namespace Huobi.Client.Websocket.Messages.MarketData.Values;
+
+public enum TradeSide
 {
-    public enum TradeSide
-    {
-        Buy,
-        Sell
-    }
+    Buy,
+    Sell
 }

--- a/src/Huobi.Client.Websocket/Serializer/Converters/OrderBookLevelConverter.cs
+++ b/src/Huobi.Client.Websocket/Serializer/Converters/OrderBookLevelConverter.cs
@@ -5,49 +5,48 @@ using Huobi.Client.Websocket.Messages.MarketData.Values;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Huobi.Client.Websocket.Serializer.Converters
+namespace Huobi.Client.Websocket.Serializer.Converters;
+
+internal class OrderBookLevelConverter : JsonConverter
 {
-    internal class OrderBookLevelConverter : JsonConverter
+    private readonly OrderBookSide _side;
+
+    public OrderBookLevelConverter(OrderBookSide side)
     {
-        private readonly OrderBookSide _side;
+        _side = side;
+    }
 
-        public OrderBookLevelConverter(OrderBookSide side)
+    public override bool CanWrite => false;
+
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(decimal[][]);
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override object ReadJson(
+        JsonReader reader,
+        Type objectType,
+        object? existingValue,
+        JsonSerializer serializer)
+    {
+        var bookLevelList = new List<BookLevel>();
+        var data = JArray.Load(reader);
+
+        foreach (var source in data)
         {
-            _side = side;
-        }
-
-        public override bool CanWrite => false;
-
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(decimal[][]);
-        }
-
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override object ReadJson(
-            JsonReader reader,
-            Type objectType,
-            object? existingValue,
-            JsonSerializer serializer)
-        {
-            var bookLevelList = new List<BookLevel>();
-            var data = JArray.Load(reader);
-
-            foreach (var source in data)
+            var array = source.ToArray();
+            if (array.Length == 2)
             {
-                var array = source.ToArray();
-                if (array.Length == 2)
-                {
-                    var bookLevel = new BookLevel(_side, (decimal)array[0], (decimal)array[1]);
-                    bookLevelList.Add(bookLevel);
-                }
+                var bookLevel = new BookLevel(_side, (decimal)array[0], (decimal)array[1]);
+                bookLevelList.Add(bookLevel);
             }
-
-            return bookLevelList.ToArray();
         }
+
+        return bookLevelList.ToArray();
     }
 }

--- a/src/Huobi.Client.Websocket/Serializer/Converters/UnixMillisecondsToDateTimeOffsetConverter.cs
+++ b/src/Huobi.Client.Websocket/Serializer/Converters/UnixMillisecondsToDateTimeOffsetConverter.cs
@@ -2,41 +2,40 @@
 using System.Globalization;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Serializer.Converters
+namespace Huobi.Client.Websocket.Serializer.Converters;
+
+internal class UnixMillisecondsToDateTimeOffsetConverter : JsonConverter
 {
-    internal class UnixMillisecondsToDateTimeOffsetConverter : JsonConverter
+    public override bool CanConvert(Type objectType)
     {
-        public override bool CanConvert(Type objectType)
+        return objectType == typeof(DateTimeOffset);
+    }
+
+    public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+    {
+        if (value is DateTimeOffset dateTimeOffset)
         {
-            return objectType == typeof(DateTimeOffset);
+            var ms = dateTimeOffset.ToUnixTimeMilliseconds();
+            writer.WriteRawValue(ms.ToString(CultureInfo.InvariantCulture));
+        }
+        else
+        {
+            writer.WriteRawValue(value?.ToString());
+        }
+    }
+
+    public override object? ReadJson(
+        JsonReader reader,
+        Type objectType,
+        object? existingValue,
+        JsonSerializer serializer)
+    {
+        if (reader.Value is long num
+            || reader.Value is string str && long.TryParse(str, out num))
+        {
+            return DateTimeOffset.FromUnixTimeMilliseconds(num);
         }
 
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-        {
-            if (value is DateTimeOffset dateTimeOffset)
-            {
-                var ms = dateTimeOffset.ToUnixTimeMilliseconds();
-                writer.WriteRawValue(ms.ToString(CultureInfo.InvariantCulture));
-            }
-            else
-            {
-                writer.WriteRawValue(value?.ToString());
-            }
-        }
-
-        public override object? ReadJson(
-            JsonReader reader,
-            Type objectType,
-            object? existingValue,
-            JsonSerializer serializer)
-        {
-            if (reader.Value is long num
-             || reader.Value is string str && long.TryParse(str, out num))
-            {
-                return DateTimeOffset.FromUnixTimeMilliseconds(num);
-            }
-
-            return null;
-        }
+        return null;
     }
 }

--- a/src/Huobi.Client.Websocket/Serializer/HuobiSerializer.cs
+++ b/src/Huobi.Client.Websocket/Serializer/HuobiSerializer.cs
@@ -4,114 +4,113 @@ using Huobi.Client.Websocket.Serializer.Converters;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
-namespace Huobi.Client.Websocket.Serializer
+namespace Huobi.Client.Websocket.Serializer;
+
+public class HuobiSerializer : IHuobiSerializer
 {
-    public class HuobiSerializer : IHuobiSerializer
+    private readonly ILogger<HuobiSerializer> _logger;
+
+    public HuobiSerializer(ILogger<HuobiSerializer> logger)
     {
-        private readonly ILogger<HuobiSerializer> _logger;
+        _logger = logger;
+    }
 
-        public HuobiSerializer(ILogger<HuobiSerializer> logger)
+    public string Serialize(object input)
+    {
+        try
         {
-            _logger = logger;
+            var serialized = JsonConvert.SerializeObject(
+                input,
+                new HuobiEnumJsonConverter(),
+                new UnixMillisecondsToDateTimeOffsetConverter());
+            return serialized;
+        }
+        catch (JsonSerializationException ex)
+        {
+            _logger.LogError(ex, $"Unable to serialize object! Error: {ex.Message}");
+            throw;
+        }
+    }
+
+    public bool TryDeserializeIfContains<T>(
+        string input,
+        string containsValue,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class
+    {
+        if (!input.Contains(containsValue))
+        {
+            deserialized = null;
+            return false;
         }
 
-        public string Serialize(object input)
+        deserialized = Deserialize<T>(input);
+        return deserialized != null;
+    }
+
+    public bool TryDeserializeIfContains<T>(
+        string input,
+        string[] containsValues,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class
+    {
+        if (containsValues.Any(x => !input.Contains(x)))
         {
-            try
-            {
-                var serialized = JsonConvert.SerializeObject(
-                    input,
-                    new HuobiEnumJsonConverter(),
-                    new UnixMillisecondsToDateTimeOffsetConverter());
-                return serialized;
-            }
-            catch (JsonSerializationException ex)
-            {
-                _logger.LogError(ex, $"Unable to serialize object! Error: {ex.Message}");
-                throw;
-            }
+            deserialized = null;
+            return false;
         }
 
-        public bool TryDeserializeIfContains<T>(
-            string input,
-            string containsValue,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class
-        {
-            if (!input.Contains(containsValue))
-            {
-                deserialized = null;
-                return false;
-            }
+        deserialized = Deserialize<T>(input);
+        return deserialized != null;
+    }
 
-            deserialized = Deserialize<T>(input);
-            return deserialized != null;
+    public bool TryDeserializeIfContains<T>(
+        string input,
+        string containsValue,
+        string notContainsValue,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class
+    {
+        if (input.Contains(notContainsValue))
+        {
+            deserialized = null;
+            return false;
         }
 
-        public bool TryDeserializeIfContains<T>(
-            string input,
-            string[] containsValues,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class
-        {
-            if (containsValues.Any(x => !input.Contains(x)))
-            {
-                deserialized = null;
-                return false;
-            }
+        return TryDeserializeIfContains(input, containsValue, out deserialized);
+    }
 
-            deserialized = Deserialize<T>(input);
-            return deserialized != null;
+    public bool TryDeserializeIfContains<T>(
+        string input,
+        string[] containsValues,
+        string[] notContainsValues,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class
+    {
+        if (notContainsValues.Any(input.Contains))
+        {
+            deserialized = null;
+            return false;
         }
 
-        public bool TryDeserializeIfContains<T>(
-            string input,
-            string containsValue,
-            string notContainsValue,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class
-        {
-            if (input.Contains(notContainsValue))
-            {
-                deserialized = null;
-                return false;
-            }
+        return TryDeserializeIfContains(input, containsValues, out deserialized);
+    }
 
-            return TryDeserializeIfContains(input, containsValue, out deserialized);
+    [return: MaybeNull]
+    private T Deserialize<T>(string input)
+    {
+        try
+        {
+            var deserialized = JsonConvert.DeserializeObject<T>(
+                input,
+                new HuobiEnumJsonConverter(),
+                new UnixMillisecondsToDateTimeOffsetConverter());
+            return deserialized;
         }
-
-        public bool TryDeserializeIfContains<T>(
-            string input,
-            string[] containsValues,
-            string[] notContainsValues,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class
+        catch (JsonSerializationException ex)
         {
-            if (notContainsValues.Any(input.Contains))
-            {
-                deserialized = null;
-                return false;
-            }
-
-            return TryDeserializeIfContains(input, containsValues, out deserialized);
-        }
-
-        [return: MaybeNull]
-        private T Deserialize<T>(string input)
-        {
-            try
-            {
-                var deserialized = JsonConvert.DeserializeObject<T>(
-                    input,
-                    new HuobiEnumJsonConverter(),
-                    new UnixMillisecondsToDateTimeOffsetConverter());
-                return deserialized;
-            }
-            catch (JsonSerializationException ex)
-            {
-                _logger.LogError(ex, $"Unable to deserialize object: {input}! Error: {ex.Message}");
-                throw;
-            }
+            _logger.LogError(ex, $"Unable to deserialize object: {input}! Error: {ex.Message}");
+            throw;
         }
     }
 }

--- a/src/Huobi.Client.Websocket/Serializer/IHuobiSerializer.cs
+++ b/src/Huobi.Client.Websocket/Serializer/IHuobiSerializer.cs
@@ -1,35 +1,34 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
-namespace Huobi.Client.Websocket.Serializer
+namespace Huobi.Client.Websocket.Serializer;
+
+public interface IHuobiSerializer
 {
-    public interface IHuobiSerializer
-    {
-        string Serialize(object input);
+    string Serialize(object input);
 
-        bool TryDeserializeIfContains<T>(
-            string input,
-            string containsValue,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class;
+    bool TryDeserializeIfContains<T>(
+        string input,
+        string containsValue,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class;
 
-        bool TryDeserializeIfContains<T>(
-            string input,
-            string[] containsValues,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class;
+    bool TryDeserializeIfContains<T>(
+        string input,
+        string[] containsValues,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class;
 
-        bool TryDeserializeIfContains<T>(
-            string input,
-            string containsValue,
-            string notContainsValue,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class;
+    bool TryDeserializeIfContains<T>(
+        string input,
+        string containsValue,
+        string notContainsValue,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class;
 
-        bool TryDeserializeIfContains<T>(
-            string input,
-            string[] containsValues,
-            string[] notContainsValues,
-            [MaybeNullWhen(false)] out T deserialized)
-            where T : class;
-    }
+    bool TryDeserializeIfContains<T>(
+        string input,
+        string[] containsValues,
+        string[] notContainsValues,
+        [MaybeNullWhen(false)] out T deserialized)
+        where T : class;
 }

--- a/src/Huobi.Client.Websocket/ServicesRegistrator.cs
+++ b/src/Huobi.Client.Websocket/ServicesRegistrator.cs
@@ -5,29 +5,28 @@ using Huobi.Client.Websocket.Serializer;
 using Huobi.Client.Websocket.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Huobi.Client.Websocket
+namespace Huobi.Client.Websocket;
+
+public static class ServicesRegistrator
 {
-    public static class ServicesRegistrator
+    public static IServiceCollection AddHuobiWebsocketServices(this IServiceCollection serviceCollection)
     {
-        public static IServiceCollection AddHuobiWebsocketServices(this IServiceCollection serviceCollection)
-        {
-            serviceCollection.AddTransient<IHuobiSerializer, HuobiSerializer>();
-            serviceCollection.AddTransient<IHuobiDateTimeProvider, HuobiDateTimeProvider>();
+        serviceCollection.AddTransient<IHuobiSerializer, HuobiSerializer>();
+        serviceCollection.AddTransient<IHuobiDateTimeProvider, HuobiDateTimeProvider>();
 
-            serviceCollection.AddTransient<IHuobiSignature, HuobiSignature>();
-            serviceCollection.AddTransient<IHuobiAuthenticationRequestFactory, HuobiAuthenticationRequestFactory>();
+        serviceCollection.AddTransient<IHuobiSignature, HuobiSignature>();
+        serviceCollection.AddTransient<IHuobiAuthenticationRequestFactory, HuobiAuthenticationRequestFactory>();
 
-            serviceCollection.AddTransient<IHuobiGenericWebsocketCommunicator, HuobiGenericWebsocketCommunicator>();
-            serviceCollection.AddTransient<IHuobiMarketWebsocketCommunicator, HuobiMarketWebsocketCommunicator>();
-            serviceCollection.AddTransient<IHuobiMarketByPriceWebsocketCommunicator, HuobiMarketByPriceWebsocketCommunicator>();
-            serviceCollection.AddTransient<IHuobiAccountWebsocketCommunicator, HuobiAccountWebsocketCommunicator>();
+        serviceCollection.AddTransient<IHuobiGenericWebsocketCommunicator, HuobiGenericWebsocketCommunicator>();
+        serviceCollection.AddTransient<IHuobiMarketWebsocketCommunicator, HuobiMarketWebsocketCommunicator>();
+        serviceCollection.AddTransient<IHuobiMarketByPriceWebsocketCommunicator, HuobiMarketByPriceWebsocketCommunicator>();
+        serviceCollection.AddTransient<IHuobiAccountWebsocketCommunicator, HuobiAccountWebsocketCommunicator>();
 
-            serviceCollection.AddTransient<IHuobiGenericWebsocketClient, HuobiGenericWebsocketClient>();
-            serviceCollection.AddTransient<IHuobiMarketWebsocketClient, HuobiMarketWebsocketClient>();
-            serviceCollection.AddTransient<IHuobiMarketByPriceWebsocketClient, HuobiMarketByPriceWebsocketClient>();
-            serviceCollection.AddTransient<IHuobiAccountWebsocketClient, HuobiAccountWebsocketClient>();
+        serviceCollection.AddTransient<IHuobiGenericWebsocketClient, HuobiGenericWebsocketClient>();
+        serviceCollection.AddTransient<IHuobiMarketWebsocketClient, HuobiMarketWebsocketClient>();
+        serviceCollection.AddTransient<IHuobiMarketByPriceWebsocketClient, HuobiMarketByPriceWebsocketClient>();
+        serviceCollection.AddTransient<IHuobiAccountWebsocketClient, HuobiAccountWebsocketClient>();
 
-            return serviceCollection;
-        }
+        return serviceCollection;
     }
 }

--- a/src/Huobi.Client.Websocket/Utils/HuobiDateTimeProvider.cs
+++ b/src/Huobi.Client.Websocket/Utils/HuobiDateTimeProvider.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Utils
+namespace Huobi.Client.Websocket.Utils;
+
+public class HuobiDateTimeProvider : IHuobiDateTimeProvider
 {
-    public class HuobiDateTimeProvider : IHuobiDateTimeProvider
-    {
-        public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
-    }
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
 }

--- a/src/Huobi.Client.Websocket/Utils/IHuobiDateTimeProvider.cs
+++ b/src/Huobi.Client.Websocket/Utils/IHuobiDateTimeProvider.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Utils
+namespace Huobi.Client.Websocket.Utils;
+
+public interface IHuobiDateTimeProvider
 {
-    public interface IHuobiDateTimeProvider
-    {
-        DateTimeOffset UtcNow { get; }
-    }
+    DateTimeOffset UtcNow { get; }
 }

--- a/src/Huobi.Client.Websocket/Utils/Validations.cs
+++ b/src/Huobi.Client.Websocket/Utils/Validations.cs
@@ -1,28 +1,27 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Utils
-{
-    public static class Validations
-    {
-        public static void ValidateInput<T>(T? value, string name)
-            where T : class
-        {
-            if (value is default(T))
-            {
-                throw new ArgumentNullException(
-                    name,
-                    $"{name} value cannot be null! Value: {value}");
-            }
-        }
+namespace Huobi.Client.Websocket.Utils;
 
-        public static void ValidateInput(string? value, string name)
+public static class Validations
+{
+    public static void ValidateInput<T>(T? value, string name)
+        where T : class
+    {
+        if (value is default(T))
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentNullException(
-                    name,
-                    $"{name} value cannot be null or empty! Value: {value}");
-            }
+            throw new ArgumentNullException(
+                name,
+                $"{name} value cannot be null! Value: {value}");
+        }
+    }
+
+    public static void ValidateInput(string? value, string name)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            throw new ArgumentNullException(
+                name,
+                $"{name} value cannot be null or empty! Value: {value}");
         }
     }
 }

--- a/src/Huobi.Client.Websocket/Utils/ZonedDateTimeExtensions.cs
+++ b/src/Huobi.Client.Websocket/Utils/ZonedDateTimeExtensions.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace Huobi.Client.Websocket.Utils
+namespace Huobi.Client.Websocket.Utils;
+
+public static class ZonedDateTimeExtensions
 {
-    public static class ZonedDateTimeExtensions
+    public static string ToHuobiUtcString(this DateTimeOffset dateTime)
     {
-        public static string ToHuobiUtcString(this DateTimeOffset dateTime)
-        {
-            return dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss");
-        }
+        return dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss");
     }
 }

--- a/test/Huobi.Client.Websocket.ComponentTests/Huobi.Client.Websocket.ComponentTests.csproj
+++ b/test/Huobi.Client.Websocket.ComponentTests/Huobi.Client.Websocket.ComponentTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Huobi.Client.Websocket.ComponentTests/Huobi.Client.Websocket.ComponentTests.csproj
+++ b/test/Huobi.Client.Websocket.ComponentTests/Huobi.Client.Websocket.ComponentTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Huobi.Client.Websocket.Tests/Huobi.Client.Websocket.Tests.csproj
+++ b/test/Huobi.Client.Websocket.Tests/Huobi.Client.Websocket.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Huobi.Client.Websocket.Tests/Huobi.Client.Websocket.Tests.csproj
+++ b/test/Huobi.Client.Websocket.Tests/Huobi.Client.Websocket.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test_integration/Huobi.Client.Websocket.Sample/Huobi.Client.Websocket.Sample.csproj
+++ b/test_integration/Huobi.Client.Websocket.Sample/Huobi.Client.Websocket.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test_integration/Huobi.Client.Websocket.Sample/Huobi.Client.Websocket.Sample.csproj
+++ b/test_integration/Huobi.Client.Websocket.Sample/Huobi.Client.Websocket.Sample.csproj
@@ -10,13 +10,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test_integration/Huobi.Client.Websocket.Tests.Integration/Huobi.Client.Websocket.Tests.Integration.csproj
+++ b/test_integration/Huobi.Client.Websocket.Tests.Integration/Huobi.Client.Websocket.Tests.Integration.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test_integration/Huobi.Client.Websocket.Tests.Integration/Huobi.Client.Websocket.Tests.Integration.csproj
+++ b/test_integration/Huobi.Client.Websocket.Tests.Integration/Huobi.Client.Websocket.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
I've exposed the underlying `Subject<T>` members in all the `xxxClientStreams` classes. This is because I want to be able to stream fake messages for testing my program which uses this library. Although that was already possible by using fake `xxxCommunicator` objects, that method is very clunky and requires that I send raw text instead of just POCO objects. There is no good reason for hiding the `Subject<T>` members behind `IObservable<T>`, so the most straight-forward way to enable easy testing is to just expose the `Subject<T>` members directly.

I've also added the `net6` target framework and updated the build files to use the newer SDK.

I've also updated all NuGet packages to the latest versions.